### PR TITLE
Added exception check for resources

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -147,22 +147,23 @@ func addExceptionsToRuleSet(ruleSet assertion.RuleSet, exceptions []RuleExceptio
 	rules := []assertion.Rule{}
 	for _, rule := range ruleSet.Rules {
 		for _, e := range exceptions {
-			if len(rule.Resources) > 0 {
-				if assertion.SliceContains(rule.Resources, e.ResourceType) &&
-					rule.ID == e.RuleID &&
-					(rule.Category == e.ResourceCategory || e.ResourceCategory == "resources") {
-					rule.Except = append(rule.Except, e.ResourceID)
-				}
-			} else if rule.ID == e.RuleID &&
-				rule.Resource == e.ResourceType &&
-				(rule.Category == e.ResourceCategory || rule.Category == "") {
-				rule.Except = append(rule.Except, e.ResourceID)
-			}
+			if resourceMatch(rule, e) &&
+			    rule.ID == e.RuleID &&
+					   (rule.Category == e.ResourceCategory || e.ResourceCategory == "resources" || rule.Category == "") {
+										rule.Except = append(rule.Except, e.ResourceID)
+					}
 		}
 		rules = append(rules, rule)
 	}
 	ruleSet.Rules = rules
 	return ruleSet
+}
+
+func resourceMatch(rule assertion.Rule, exception RuleException) bool {
+	if (assertion.SliceContains(rule.Resources, exception.ResourceType) || rule.Resource == exception.ResourceType) {
+		return true
+	}
+	return false
 }
 
 func validateRules(filenames []string, w ReportWriter) int {

--- a/cli/app.go
+++ b/cli/app.go
@@ -147,7 +147,13 @@ func addExceptionsToRuleSet(ruleSet assertion.RuleSet, exceptions []RuleExceptio
 	rules := []assertion.Rule{}
 	for _, rule := range ruleSet.Rules {
 		for _, e := range exceptions {
-			if rule.ID == e.RuleID &&
+			if len(rule.Resources) > 0 {
+				if assertion.SliceContains(rule.Resources, e.ResourceType) &&
+					rule.ID == e.RuleID &&
+					(rule.Category == e.ResourceCategory || e.ResourceCategory == "resources") {
+					rule.Except = append(rule.Except, e.ResourceID)
+				}
+			} else if rule.ID == e.RuleID &&
 				rule.Resource == e.ResourceType &&
 				(rule.Category == e.ResourceCategory || rule.Category == "") {
 				rule.Except = append(rule.Except, e.ResourceID)

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -188,3 +188,42 @@ func TestValidateRules(t *testing.T) {
 	validateRules(filenames, w)
 	assert.Empty(t, w.Report.Violations, "Expecting empty report for validateRules")
 }
+
+func TestResourceMatch(t *testing.T) {
+	testRule := []assertion.Rule{
+		{
+			ID:        "RULE_1",
+			Category:  "resource",
+			Resources: []string{"aws_instance", "aws_s3_bucket"},
+		},
+		{
+			ID:       "RULE_2",
+			Category: "resource",
+			Resource: "aws_s3_bucket",
+		},
+	}
+	profileExceptions := []RuleException{
+		{
+			RuleID:           "RULE_1",
+			ResourceCategory: "resource",
+			ResourceType:     "aws_instance",
+			Comments:         "Testing",
+			ResourceID:       "my-special-resource",
+		},
+		{
+			RuleID:           "RULE_2",
+			ResourceCategory: "resources",
+			ResourceType:     "aws_s3_bucket",
+			Comments:         "Testing",
+			ResourceID:       "my-special-bucket",
+		},
+	}
+
+	if !resourceMatch(testRule[0], profileExceptions[0]) {
+		t.Errorf("Expecting exception resource to be found in rule resources")
+	}
+	if !resourceMatch(testRule[1], profileExceptions[1]) {
+		t.Errorf("Expecting one to one match with exception resource and rule resource")
+	}
+
+}


### PR DESCRIPTION
Added additional check for `addExceptionsToRuleSet` for rules that use `resources` without explicitly setting the `ResourceCategory` to `resources`. Conditional will check for whether the exception `ResourceType` in the rule `Resources`.