### PR TITLE
follow proper logging convention

### DIFF
--- a/assertion/ip_operations.go
+++ b/assertion/ip_operations.go
@@ -2,7 +2,6 @@ package assertion
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"strings"
 )
@@ -23,12 +22,12 @@ func getIPObject(addressString string) (net.IP, error) {
 func isSubnet(ipAddressStr string, supernet string) bool {
 	ipAddress, parseError := getIPObject(ipAddressStr)
 	if parseError != nil {
-		log.Printf("%v", parseError)
+		Debugf("%v", parseError)
 		return false
 	}
 	_, superNetwork, err := net.ParseCIDR(supernet)
 	if err != nil {
-		log.Fatal("error parsing supernet:", err)
+		Debugf("error parsing supernet: %v", err)
 	}
 	return superNetwork.Contains(ipAddress)
 }


### PR DESCRIPTION
I created a bug when closing #14 , I did not follow the debug logging convention for this tool and it resulted in log messages being printed out in non-debug mode, which corrupted the JSON output of the tool from being parsed.

@jeffb4 @lhitchon let me know if this works, thanks.