### PR TITLE
Use -u flag to check for package updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run:
           name: Release
           command: |
-            go get github.com/goreleaser/goreleaser
+            go get -u github.com/goreleaser/goreleaser
             goreleaser release --skip-validate
 
 workflows:


### PR DESCRIPTION
CircleCI release if failing due to missing dependencies. Use the -u flag to update dependencies.