### PR TITLE
Removing build caching for /go/pkg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,6 @@ jobs:
       - run: 
           name: Test
           command: make test
-      - save_cache:
-          key: v1-config-lint-cache
-          paths:
-            - "/go/pkg"
       - persist_to_workspace:
           root: .
           paths: .


### PR DESCRIPTION
Caching during the build seems to be interfering during the release stage, so we're removing it.