### PR TITLE
Add S3 bucket encryption to terraform built-in

### DIFF
--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -420,6 +420,17 @@ rules:
     tags:
       - s3
 
+  - id: S3_BUCKET_ENCRYPTION
+    message: S3 bucket should be encrypted
+    resource: aws_s3_bucket
+    severity: FAILURE
+    assertions:
+      - key: "@"
+        op: has-properties
+        value: server_side_encryption_configuration
+    tags:
+      - s3
+
   - id: SNS_TOPIC_POLICY_WILDCARD_PRINCIPAL
     message: Should not use wildcard Principal in SNS topic policy
     resource: aws_sns_topic_policy

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stelligent/config-lint/assertion"
 	"github.com/stelligent/config-lint/linter"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func loadRules(t *testing.T, filename string) assertion.RuleSet {
@@ -73,6 +74,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"s3.tf", "S3_NOT_PRINCIPAL", 0, 0},
 		{"s3.tf", "S3_BUCKET_POLICY_WILDCARD_PRINCIPAL", 1, 0},
 		{"s3.tf", "S3_BUCKET_POLICY_WILDCARD_ACTION", 1, 0},
+		{"s3.tf", "S3_BUCKET_ENCRYPTION", 0, 1},
 		{"s3.tf", "S3_BUCKET_OBJECT_ENCRYPTION", 0, 1},
 		{"sns.tf", "SNS_TOPIC_POLICY_WILDCARD_PRINCIPAL", 1, 0},
 		{"sns.tf", "SNS_TOPIC_POLICY_NOT_ACTION", 0, 0},


### PR DESCRIPTION
Adding a Failure rule for S3 Bucket encryption, similar to the rule for S3 Bucket Object encryption.