### PR TITLE
Add Readme for VS Code remote

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM circleci/golang:1.11
+ENV GO111MODULE=on
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Or your actual UID, GID on Linux if not the default 1000
+ARG USERNAME=circleci
+ARG USER_UID=3434
+ARG USER_GID=$USER_UID
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "Go",
+	"dockerFile": "Dockerfile",
+	"appPort": 9000,
+	"extensions": [
+		"ms-vscode.go"
+	],
+	"runArgs": [
+		// Comment out the next line to run as root instead. Linux users, 
+		// update Dockerfile with your user's UID/GID if not 1000.
+		"-u",
+		"circleci",
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
+	"settings": {
+		"go.gopath": "/go",
+		"go.inferGopath": true,
+		"go.useLanguageServer": true
+	},
+	"postCreateCommand": "echo 'make vscoderemotedev'; make vscoderemotedev"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 		"ms-vscode.go"
 	],
 	"runArgs": [
-		// Comment out the next line to run as root instead. Linux users, 
+		// Comment out the next two lines to run as root instead. Linux users, 
 		// update Dockerfile with your user's UID/GID if not 1000.
 		"-u",
 		"circleci",

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,30 @@ CLI_FILES = $(shell find cli linter assertion -name \*.go)
 
 default: all
 
+devdeps:
+	@echo "=== dev dependencies ==="
+	@go get "github.com/gobuffalo/packr/..."
+	@go get -u golang.org/x/lint/golint
+	@go get "github.com/fzipp/gocyclo"
+
+vscoderemotedeps:
+	@echo "=== vscode remote dev dependencies ==="
+	# Install gocode-gomod
+	@go get -x -d github.com/stamblerre/gocode 2>&1 \
+	&& go build -o gocode-gomod github.com/stamblerre/gocode \
+	&& mv gocode-gomod $$GOPATH/bin/ \
+	&& go get -u -v \
+	github.com/mdempsky/gocode \
+	github.com/uudashr/gopkgs/cmd/gopkgs \
+	github.com/ramya-rao-a/go-outline \
+	github.com/acroca/go-symbols \
+	golang.org/x/tools/cmd/gopls \
+	golang.org/x/tools/cmd/guru \
+	golang.org/x/tools/cmd/gorename \
+	github.com/go-delve/delve/cmd/dlv \
+	golang.org/x/tools/cmd/goimports \
+	github.com/rogpeppe/godef  2>&1
+
 deps:
 	@echo "=== dependencies ==="
 	go mod download
@@ -51,6 +75,8 @@ $(BUILD_DIR)/config-lint: $(CLI_FILES)
 build: gen $(BUILD_DIR)/config-lint
 
 all: clean deps test build
+dev: deps devdeps
+vscoderemotedev: deps devdeps vscoderemotedeps
 
 clean:
 	@echo "=== cleaning ==="

--- a/README.md
+++ b/README.md
@@ -163,7 +163,16 @@ The files will *not* be scanned for violations.
 
 The overall design in described [here](docs/design.md).
 
-# Development
+# VS Code Remote Development
+The preferred method of developing is to use the VS Code Remote development functionality.
+
+- Install the VS Code [Remote Development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
+- Open the repo in VS Code
+- When prompted "`Folder contains a dev container configuration file. Reopen folder to develop in a container`" click the "`Reopen in Container`" button
+- When opening in the future use the "`config-lint [Dev Container]`" option
+
+
+# Local Development
 
 ## Prerequisites 
 - [Install golang](https://golang.org/doc/install)


### PR DESCRIPTION
Adding support for VS Code remote development. 
Uses the same docker image as our CI/CD process.
I had to add in the `vscoderemotedeps` modules so the remote VS Code server could handle the normal functions like code completion, linting, .... 

@kmonihen  It would be good for some people to test this out before we merge it.