### PR TITLE
Add rule to warn for -1 protocol in security group

### DIFF
--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -123,9 +123,9 @@ rules:
       - sg
       - ec2
 
-  - id: SG_INGRESS_ALL_PROTOCALS
+  - id: SG_INGRESS_ALL_PROTOCOLS
     resource: aws_security_group
-    message: Should make individual rules per protocol since all protocals ignores ports
+    message: Best practices recommend not opening all protocols and ports to ingress traffic
     assertions:
       - not:
         - key: "ingress[].protocol"
@@ -135,9 +135,9 @@ rules:
     tags:
       - sg
 
-  - id: SG_EGRESS_ALL_PROTOCALS
+  - id: SG_EGRESS_ALL_PROTOCOLS
     resource: aws_security_group
-    message: Should make individual rules per protocol since all protocals ignores ports
+    message: Best practices recommend not opening all protocols and ports to egress traffic
     assertions:
       - not:
         - key: "egress[].protocol"

--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -127,9 +127,10 @@ rules:
     resource: aws_security_group
     message: Should make individual rules per protocol since all protocals ignores ports
     assertions:
-      - key: "ingress[].protocol"
-        op: eq
-        value: "-1"
+      - not:
+        - key: "ingress[].protocol"
+          op: contains
+          value: "-1"
     severity: WARNING
     tags:
       - sg
@@ -138,9 +139,10 @@ rules:
     resource: aws_security_group
     message: Should make individual rules per protocol since all protocals ignores ports
     assertions:
-      - key: "egress[].protocol"
-        op: eq
-        value: "-1"
+      - not:
+        - key: "egress[].protocol"
+          op: contains
+          value: "-1"
     severity: WARNING
     tags:
       - sg

--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -123,6 +123,28 @@ rules:
       - sg
       - ec2
 
+  - id: SG_INGRESS_ALL_PROTOCALS
+    resource: aws_security_group
+    message: Should make individual rules per protocol since all protocals ignores ports
+    assertions:
+      - key: "ingress[].protocol"
+        op: eq
+        value: "-1"
+    severity: WARNING
+    tags:
+      - sg
+
+  - id: SG_EGRESS_ALL_PROTOCALS
+    resource: aws_security_group
+    message: Should make individual rules per protocol since all protocals ignores ports
+    assertions:
+      - key: "egress[].protocol"
+        op: eq
+        value: "-1"
+    severity: WARNING
+    tags:
+      - sg
+
   - id: CLOUDFRONT_DISTRIBUTION_LOGGING
     message: CloudFront Distribution must configure logging
     resource: aws_cloudfront_distribution

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -52,6 +52,8 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"security-groups.tf", "SG_INGRESS_PORT_RANGE", 0, 0},
 		{"security-groups.tf", "SG_EGRESS_PORT_RANGE", 0, 0},
 		{"security-groups.tf", "SG_MISSING_EGRESS", 0, 0},
+		{"security-groups.tf", "SG_INGRESS_ALL_PROTOCALS", 1, 0},
+		{"security-groups.tf", "SG_EGRESS_ALL_PROTOCALS", 3, 0},
 		{"cloudfront.tf", "CLOUDFRONT_DISTRIBUTION_LOGGING", 0, 1},
 		{"cloudfront.tf", "CLOUDFRONT_DISTRIBUTION_ORIGIN_POLICY", 0, 0},
 		{"cloudfront.tf", "CLOUDFRONT_DISTRIBUTION_DISTRIBUTION_PROTOCOl", 0, 0},

--- a/cli/testdata/builtin/terraform/security-groups.tf
+++ b/cli/testdata/builtin/terraform/security-groups.tf
@@ -38,10 +38,10 @@ resource "aws_security_group" "sg_all_protocols" {
 
   ingress {
     protocol    = "-1"
-    cidr_blocks = ["1.2.3.4/32"]
+    cidr_blocks = "1.2.3.4/32"
   }
   egress {
     protocol    = "-1"
-    cidr_blocks = ["1.2.3.4/32"]
+    cidr_blocks = "1.2.3.4/32"
   }
 }

--- a/cli/testdata/builtin/terraform/security-groups.tf
+++ b/cli/testdata/builtin/terraform/security-groups.tf
@@ -31,3 +31,17 @@ resource "aws_security_group" "sg_ssh" {
     cidr_blocks     = ["0.0.0.0/0"]
   }
 }
+
+resource "aws_security_group" "sg_all_protocols" {
+  name = "all_all_protocols"
+  description = "Allow all protocols and ports"
+
+  ingress {
+    protocol    = "-1"
+    cidr_blocks = "10.0.1.10/32" # A random IP is used to prevent a quad 0 warning
+  }
+  egress {
+    protocol    = "-1"
+    cidr_blocks = "10.0.1.10/32" # A random IP is used to prevent a quad 0 warning
+  }
+}

--- a/cli/testdata/builtin/terraform/security-groups.tf
+++ b/cli/testdata/builtin/terraform/security-groups.tf
@@ -38,10 +38,10 @@ resource "aws_security_group" "sg_all_protocols" {
 
   ingress {
     protocol    = "-1"
-    cidr_blocks = "10.0.1.10/32" # A random IP is used to prevent a quad 0 warning
+    cidr_blocks = ["1.2.3.4/32"]
   }
   egress {
     protocol    = "-1"
-    cidr_blocks = "10.0.1.10/32" # A random IP is used to prevent a quad 0 warning
+    cidr_blocks = ["1.2.3.4/32"]
   }
 }


### PR DESCRIPTION
Security group best practices indicate that using the protocol of "-1" (all protocols and all ports) is discouraged. Added rules to warn if "-1" is used on either ingress or egress security group rules.