### PR TITLE
Additional tests for file function and new template syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,5 +21,5 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/zclconf/go-cty v1.1.1
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
-	golang.org/x/tools v0.0.0-20200106190116-7be0a674c9fc // indirect
+	golang.org/x/tools v0.0.0-20200107184032-11e9d9cc0042 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -463,6 +463,8 @@ golang.org/x/tools v0.0.0-20200103221440-774c71fcf114 h1:DnSr2mCsxyCE6ZgIkmcWUQY
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200106190116-7be0a674c9fc h1:MR2F33ipDGog0C4eMhU6u9o3q6c3dvYis2aG6Jl12Wg=
 golang.org/x/tools v0.0.0-20200106190116-7be0a674c9fc/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200107184032-11e9d9cc0042 h1:BKiPVwWbEdmAh+5CBwk13CYeVJQRDJpDnKgDyMOGz9M=
+golang.org/x/tools v0.0.0-20200107184032-11e9d9cc0042/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -30,6 +30,8 @@ func NewLinter(ruleSet assertion.RuleSet, vs assertion.ValueSource, filenames []
 		return FileLinter{Filenames: filenames, ValueSource: vs, Loader: KubernetesResourceLoader{}}, nil
 	//TODO: Maybe leave an option to force original TerraformResourceLoader
 	case "Terraform":
+		return FileLinter{Filenames: filenames, ValueSource: vs, Loader: TerraformResourceLoader{}}, nil
+	case "Terraform12":
 		return FileLinter{Filenames: filenames, ValueSource: vs, Loader: Terraform12ResourceLoader{}}, nil
 	case "LintRules":
 		return FileLinter{Filenames: filenames, ValueSource: vs, Loader: RulesResourceLoader{}}, nil

--- a/linter/testdata/data/multi_line_content
+++ b/linter/testdata/data/multi_line_content
@@ -1,0 +1,3 @@
+multi
+line
+example

--- a/linter/testdata/data/reference_relative.tf
+++ b/linter/testdata/data/reference_relative.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "a_bucket" {
+  bucket = "${file("bucket_name")}"
+}

--- a/linter/testdata/data/template_file_example_basic
+++ b/linter/testdata/data/template_file_example_basic
@@ -1,0 +1,1 @@
+bucket-${var1}-example-${var2}

--- a/linter/testdata/data/template_file_example_conditional
+++ b/linter/testdata/data/template_file_example_conditional
@@ -1,0 +1,5 @@
+%{ if test_var == "Alpha" }
+Foo
+%{ else }
+Bar
+%{ endif ~}

--- a/linter/testdata/data/template_file_example_for_loop
+++ b/linter/testdata/data/template_file_example_for_loop
@@ -1,0 +1,3 @@
+%{ for word in words ~}
+testing:${word}
+%{ endfor ~}

--- a/linter/testdata/resources/reference_file_multi_line.tf
+++ b/linter/testdata/resources/reference_file_multi_line.tf
@@ -1,0 +1,23 @@
+//resource "aws_s3_bucket" "a_bucket" {
+//  bucket = "${file("./testdata/data/multi_line_content")}"
+//}
+
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+//data "template_file" "multi_line" {
+//  template = file("./testdata/data/multi_line_content")
+//}
+
+resource "test_resource" "test" {
+  test_value = file("./testdata/data/multi_line_content")
+}
+
+resource "test_resource2" "test2" {
+  test_value2 = <<EOT
+multi
+line
+example
+EOT
+}

--- a/linter/testdata/resources/reference_file_multi_line.tf
+++ b/linter/testdata/resources/reference_file_multi_line.tf
@@ -1,14 +1,6 @@
-//resource "aws_s3_bucket" "a_bucket" {
-//  bucket = "${file("./testdata/data/multi_line_content")}"
-//}
-
 terraform {
   required_version = ">= 0.12.0"
 }
-
-//data "template_file" "multi_line" {
-//  template = file("./testdata/data/multi_line_content")
-//}
 
 resource "test_resource" "test" {
   test_value = file("./testdata/data/multi_line_content")

--- a/linter/testdata/resources/template_file_function_basic.tf
+++ b/linter/testdata/resources/template_file_function_basic.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+variable "object_1" {
+  default = "foo"
+}
+
+variable "object_2" {
+  default = "bar"
+}
+
+resource "aws_s3_bucket" "a_bucket" {
+  bucket = templatefile("./testdata/data/template_file_example_basic", { var1 = var.object_1, var2 = var.object_2})
+}

--- a/linter/testdata/resources/template_file_function_conditional.tf
+++ b/linter/testdata/resources/template_file_function_conditional.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+variable "var1" {
+  default = "Alpha"
+}
+
+variable "var2" {
+  default = "Bravo"
+}
+
+resource "test_resource" "test" {
+  test_value =  templatefile("./testdata/data/template_file_example_conditional", { test_var = var.var1})
+}
+
+resource "test_resource" "test2" {
+  test_value2 =  templatefile("./testdata/data/template_file_example_conditional", { test_var = var.var2})
+}

--- a/linter/testdata/resources/template_file_function_for_loop.tf
+++ b/linter/testdata/resources/template_file_function_for_loop.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+variable "words" {
+  default = ["foo", "bar"]
+}
+
+resource "test" "test_resource" {
+  test_value = templatefile("./testdata/data/template_file_example_for_loop", { words = var.words})
+}


### PR DESCRIPTION
Adding tests for absolute/relative path reference/resource files, multi line files, and different types of templatefile syntax example tests. Still one test that is failing though (when a resource file and reference file are in the same directory and the resource specifies the file path as only the immediate relative reference file path (i.e `file("reference_file_in_same_dir.txt")` )