### PR TITLE
Feature/dockerhub integration issue 34

### DIFF
--- a/.dockerhub/Dockerfile
+++ b/.dockerhub/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY config-lint /
+ENTRYPOINT ["/config-lint"] 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -10,17 +10,36 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: golang:1.12
     steps:
-      - uses: actions/checkout@master
-      - name: dependencies
-        run: go mod download
-      - name: make test
-        run: make test
-      - name: release
+      -
+        name: checkout
+        uses: actions/checkout@master
+      -
+        name: setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13'
+      -
+        name: dependencies
+        run: |
+          go mod download
+      -
+        name: docker login
+        env:
+          DOCKER_USER: ${{ secrets.docker_user }}
+          DOCKER_PASSWORD: ${{ secrets.docker_password }}
+        run: |
+          echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin
+      -  
+        name: make test
+        run: |
+          export GOPATH=/home/runner/go
+          export PATH="$PATH:$GOPATH/bin"
+          make test
+      - 
+        name: release
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          args: release --skip-validate
         env:
           GITHUB_TOKEN: ${{ secrets.goreleaser }}
-        if: success()
-        run: |
-          go get github.com/goreleaser/goreleaser
-          goreleaser release --skip-validate

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -18,7 +18,7 @@ jobs:
         name: setup go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13'
+          go-version: '1.12'
       -
         name: dependencies
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,3 +35,9 @@ brews:
       name: goreleaserbot
       email: goreleaser@stelligent.com
     folder: Formula
+dockers:
+  - 
+    dockerfile: .dockerhub/Dockerfile
+    image_templates:
+    - "stelligent/config-lint:{{ .Tag }}"
+    - "stelligent/config-lint:latest"

--- a/README.md
+++ b/README.md
@@ -7,13 +7,41 @@ The configurations files can be one of several formats, such as Terraform, JSON,
 There is a built-in set of rules provided for Terraform. Custom files are used
 for other formats.
 
-# Installation 
+# Installation
+
+There are three main ways that you can install `config-lint`
+
+* homebrew
+* docker
+* manually
+
+## Homebrew
+
 You can use [Homebrew](https://brew.sh/) to install the latest version:
 
-```
+``` bash
 brew tap stelligent/tap
 brew install config-lint
 ```
+
+## Docker
+
+You can pull the latest image from [DockerHub](https://hub.docker.com/r/stelligent/config-lint):
+
+``` bash
+docker pull stelligent/config-lint
+```
+
+Note that if you choose to install and run via `docker` then you will need mount a directory to the running container so that it has access to your configuration files.
+
+``` bash
+cd /path/to/your/configs/
+docker run -v $(pwd):/foobar stelligent/config-lint -terraform /foobar/foo.tf
+--- or ---
+docker run --mount src="$(pwd)",target=/foobar,type=bind stelligent/config-lint -terraform /foobar/foo.tf
+```
+
+## Manually
 
 Alternatively, you can install manually from the [releases](https://github.com/stelligent/config-lint/releases).
 
@@ -208,4 +236,3 @@ make lint
 
 ## Releasing
 To release a new version, run `make bumpversion` to increment the patch version and push a tag to GitHub to start the release process.
-


### PR DESCRIPTION
Closes Issue #34 

This PR does the following:
* Adds DockerHub release step to push to https://hub.docker.com/r/stelligent/config-lint
* Updates documentation for installation and use with docker image
* Updates GitHub Workflow
  * use goreleaser setup action
  * use go version 1.13
  * add docker login stage
 

Docker images with tags added to GitHub Release (ignore the `Pre-Release` tag as this was only used for testing)
<img width="951" alt="Screen Shot 2020-01-13 at 11 27 12 AM" src="https://user-images.githubusercontent.com/21042050/72274068-7f793480-35f9-11ea-9117-27be51b4dbe8.png">


New Stelligent config-lint DockerHub Repo
<img width="1316" alt="Screen Shot 2020-01-13 at 11 30 56 AM" src="https://user-images.githubusercontent.com/21042050/72274069-7f793480-35f9-11ea-807e-d39b30acf175.png">
