### PR TITLE
upgrade go version and use github provided virtual environment to run workflow stages

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM golang:1.12
+FROM golang:1.13
 ENV GO111MODULE=on
 
 # Avoid warnings by switching to noninteractive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: golang:1.12
     steps:
-      - uses: actions/checkout@master
-      - name: dependencies
-        run: go mod download
-      - name: make test
-        run: make test
+      - 
+        name: checkout
+        uses: actions/checkout@master
+      -
+        name: setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13'
+      -
+        name: dependencies
+        run: |
+          go mod download
+      -  
+        name: make test
+        run: |
+          export GOPATH=/home/runner/go
+          export PATH="$PATH:$GOPATH/bin"
+          make test

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -18,7 +18,7 @@ jobs:
         name: setup go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.12'
+          go-version: '1.13'
       -
         name: dependencies
         run: |


### PR DESCRIPTION
Closes Issues #59 & #60 

* Removes `container: golang:1.12` so that we are utilizing the official GitHub virtual environment to run the workflow stages.
* Installs Go with the [setup-go action](https://github.com/actions/setup-go)
* Bumps up the Go version to `1.13`