### PR TITLE
Ensure Bucket Policy for HTTPS Access

### DIFF
--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -444,6 +444,22 @@ rules:
     tags:
       - s3
 
+  - id: S3_BUCKET_POLICY_ONLY_HTTPS
+    message: Should only allow HTTPS access to a bucket.
+    resource: aws_s3_bucket_policy
+    severity: FAILURE
+    assertions:
+      - some:
+          key: policy.Statement[]
+          expressions:
+            - key: Effect
+              op: eq
+              value: Allow
+            - key: Condition.Bool."aws:SecureTransport"
+              op: is-true
+    tags:
+      - s3
+
   - id: S3_BUCKET_ENCRYPTION
     message: S3 bucket should be encrypted
     resource: aws_s3_bucket

--- a/cli/assets/terraform12.yml
+++ b/cli/assets/terraform12.yml
@@ -444,6 +444,24 @@ rules:
     tags:
       - s3
 
+   - id: S3_BUCKET_POLICY_ONLY_HTTPS
+    message: Should only allow HTTPS access to a bucket.
+    resource: aws_s3_bucket_policy
+    severity: FAILURE
+    assertions:
+      - some:
+          key: policy.Statement[]
+          expressions:
+            - key: Effect
+              op: eq
+              value: Allow
+            - key: Condition.Bool."aws:SecureTransport"
+              op: is-true
+    tags:
+      - s3
+    tags:
+      - s3
+
   - id: S3_BUCKET_ENCRYPTION
     message: S3 bucket should be encrypted
     resource: aws_s3_bucket

--- a/example-files/config/s3-bucket-policy.tf
+++ b/example-files/config/s3-bucket-policy.tf
@@ -1,0 +1,27 @@
+resource "aws_s3_bucket" "b" {
+  bucket = "a_test_bucket"
+}
+
+resource "aws_s3_bucket_policy" "b" {
+  bucket = "${aws_s3_bucket.b.id}"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "MYBUCKETPOLICY",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "user",
+      "Action": "s3:GetBucket",
+      "Resource": "arn:aws:s3:::a_test_bucket/*",
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "true"
+        }
+      }
+    }
+  ]
+}
+POLICY
+}


### PR DESCRIPTION
This rule ensures that traffic to an S3 bucket is provided
only via HTTPS.  Note that the rule is only an allow and not a deny if
not present.  This is done so not to restrict anonymous access.

https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-policy-for-config-rule/

Resolves #78