### PR TITLE
Feature/115 add rule testing to build pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,10 @@ cyclo:
 
 test: lint cyclo
 	@echo "=== testing ==="
-	@go test ./...
+	@go test -v ./...
 
 testtf: lint cyclo
-	@echo "=== testing ==="
+	@echo "=== testing Terraform Built In Rules ==="
 	@go test -v ./cli/... -run TestTerraformBuiltInRules
 
 beta-bumpversion:

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ To run the Terraform builtin rules tests:
 make testtf
 ```
 
+More information about how to create and run tests can be found [here](docs/tests.md).
+
 ## Linting
 To lint all files (using golint):
 ```

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,32 @@
+# Tests
+
+You can run the project tests by invoking the correct make command:
+
+* `make test` -> Runs all tests residing inside the config-lint project
+* `make testtf` -> Runs all tests defined within the `TestTerraformBuiltInRules` test function.
+
+## Testing Best Practices
+
+It is best practice to always come up with **at least 2** scenarios for each test (ideally more if applicable). You want a test case that will *pass* and a test case that will *fail*. This covers the bare minimum to ensure that a rule and test case are working as expected.
+
+## Terraform
+
+Terraform rules have their own set of tests that you can use to verify that a new rule or configuration is working as expected. As noted above, the `make testtf` command will run the tests defined within the `TestTerraformBuiltInRules` test function.
+
+### Creating Terraform Tests
+
+To create a new test to validate a Terraform built in rule you need to do the following:
+* Add test case inside `TestTerraformBuiltInRules` function in the `cli/builtin_terraform_test.go` file.
+  * Example: `{"security-groups.tf", "SG_WORLD_INGRESS", 1, 0},` will run the `SG_WORLD_INGRESS` rule against the contents of the `cli/testdata/builtin/terraform/security-groups.tf` file. It is expecting there to be **1** *Warning* and **0** *Failures*
+  * The test must follow the `struct` format for `BuiltInTestCase`
+
+  ``` go
+  type BuiltInTestCase struct {
+	Filename     string
+	RuleID       string
+	WarningCount int
+	FailureCount int
+  }
+  ```
+
+  * This test case must match a valid Rule `id` from within the `cli/assets/terraform.yml` file.


### PR DESCRIPTION
Closes #115 

* Created documentation to help aid in Terraform Rule and Test development.
* Added verbosity to `make test` command to show all tests run and their respective outcome.