### PR TITLE
adding rule and test cases for aws_redshift_cluster publicly_accessible

### DIFF
--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -873,6 +873,16 @@ rules:
     tags:
       - redshift
 
+  - id: REDSHIFT_CLUSTER_PUBLICLY_ACCESSIBLE
+    message: RedshiftCluster should not be publicly accessible
+    resource: aws_redshift_cluster
+    severity: FAILURE
+    assertions:
+      - key: publicly_accessible
+        op: is-false
+    tags:
+      - redshift
+
   - id: S3_BUCKET_OBJECT_ENCRYPTION
     message: S3 Bucket Object should be encrypted
     resource: aws_s3_bucket_object

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -106,6 +106,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"kinesis.tf", "KINESIS_FIREHOSE_DELIVERY_STREAM_ENCRYPTION", 0, 1},
 		{"redshift_encryption.tf", "REDSHIFT_CLUSTER_ENCRYPTION", 0, 2},
 		{"redshift_kms.tf", "REDSHIFT_CLUSTER_KMS_KEY_ID", 1, 0},
+		{"redshift_public_access.tf", "REDSHIFT_CLUSTER_PUBLICLY_ACCESSIBLE", 0, 2},
 		{"ecs.tf", "ECS_ENVIRONMENT_SECRETS", 0, 1},
 	}
 	for _, tc := range testCases {

--- a/cli/testdata/builtin/terraform/redshift_public_access.tf
+++ b/cli/testdata/builtin/terraform/redshift_public_access.tf
@@ -1,0 +1,31 @@
+# Fail
+resource "aws_redshift_cluster" "publicly_accessible_not_set" {
+  cluster_identifier = "my-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "admin"
+  master_password    = "foobarbaz"
+  node_type          = "dc2.large"
+  cluster_type       = "single-node"
+}
+
+# Fail
+resource "aws_redshift_cluster" "publicly_accessible_set_to_true" {
+  cluster_identifier  = "my-redshift-cluster"
+  database_name       = "mydb"
+  master_username     = "admin"
+  master_password     = "foobarbaz"
+  node_type           = "dc2.large"
+  cluster_type        = "single-node"
+  publicly_accessible = true
+}
+
+# Pass
+resource "aws_redshift_cluster" "publicly_accessible_set_to_false" {
+  cluster_identifier  = "my-redshift-cluster"
+  database_name       = "mydb"
+  master_username     = "admin"
+  master_password     = "foobarbaz"
+  node_type           = "dc2.large"
+  cluster_type        = "single-node"
+  publicly_accessible = false
+}


### PR DESCRIPTION
Closes #105 

Creates a **FAILURE** rule and corresponding tests to ensure the `aws_redshift_cluster` resource has the `publicly_accessible` argument set to `false`. 

``` bash
make testtf
=== generating ===
=== linting ===
go: finding golang.org/x/lint latest
go: finding golang.org/x/tools latest
=== cyclomatic complexity ===
go: finding github.com/fzipp/gocyclo latest
57 assertion isMatch assertion/match.go:27:1
19 tf12parser (*Parser).getValuesByBlockType linter/tf12parser/parser.go:278:1
16 main main cli/app.go:91:1
WARNING: cyclomatic complexity is high
=== testing Terraform Built In Rules ===
=== RUN   TestTerraformBuiltInRules
--- PASS: TestTerraformBuiltInRules (0.10s)
PASS
ok      github.com/stelligent/config-lint/cli   0.109s
```