### PR TITLE
adding rule and test cases for aws_redshift_cluster enhanced_vpc_routing

### DIFF
--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -873,6 +873,16 @@ rules:
     tags:
       - redshift
 
+  - id: REDSHIFT_CLUSTER_ENHANCED_VPC_ROUTING
+    message: RedshiftCluster should use enhanced vpc routing
+    resource: aws_redshift_cluster
+    severity: WARNING
+    assertions:
+      - key: enhanced_vpc_routing
+        op: is-true
+    tags:
+      - redshift
+
   - id: S3_BUCKET_OBJECT_ENCRYPTION
     message: S3 Bucket Object should be encrypted
     resource: aws_s3_bucket_object

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -106,6 +106,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"kinesis.tf", "KINESIS_FIREHOSE_DELIVERY_STREAM_ENCRYPTION", 0, 1},
 		{"redshift_encryption.tf", "REDSHIFT_CLUSTER_ENCRYPTION", 0, 2},
 		{"redshift_kms.tf", "REDSHIFT_CLUSTER_KMS_KEY_ID", 1, 0},
+		{"redshift_enhanced_vpc.tf", "REDSHIFT_CLUSTER_ENHANCED_VPC_ROUTING", 2, 0},
 		{"ecs.tf", "ECS_ENVIRONMENT_SECRETS", 0, 1},
 	}
 	for _, tc := range testCases {

--- a/cli/testdata/builtin/terraform/redshift_enhanced_vpc.tf
+++ b/cli/testdata/builtin/terraform/redshift_enhanced_vpc.tf
@@ -1,0 +1,41 @@
+variable "kms_key_arn" {
+  default = "arn:aws:kms:us-east-1:1234567890:key/foobar"
+}
+
+# Warn
+resource "aws_redshift_cluster" "enhanced_vpc_routing_not_set" {
+  cluster_identifier = "my-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "admin"
+  master_password    = "foobarbaz"
+  node_type          = "dc2.large"
+  cluster_type       = "single-node"
+  encrypted          = true
+  kms_key_id         = "${var.kms_key_arn}"
+}
+
+# Pass
+resource "aws_redshift_cluster" "enhanced_vpc_routing_set_to_false" {
+  cluster_identifier   = "my-redshift-cluster"
+  database_name        = "mydb"
+  master_username      = "admin"
+  master_password      = "foobarbaz"
+  node_type            = "dc2.large"
+  cluster_type         = "single-node"
+  encrypted            = true
+  kms_key_id           = "${var.kms_key_arn}"
+  enhanced_vpc_routing = false
+}
+
+# Pass
+resource "aws_redshift_cluster" "enhanced_vpc_routing_set_to_true" {
+  cluster_identifier   = "my-redshift-cluster"
+  database_name        = "mydb"
+  master_username      = "admin"
+  master_password      = "foobarbaz"
+  node_type            = "dc2.large"
+  cluster_type         = "single-node"
+  encrypted            = true
+  kms_key_id           = "${var.kms_key_arn}"
+  enhanced_vpc_routing = true
+}


### PR DESCRIPTION
Closes #106 

Creates a **WARNING** rule and corresponding tests to ensure the `aws_redshift_cluster` resource has the `enhanced_vpc_routing` argument set to true.

``` bash
make testtf
=== generating ===
=== linting ===
go: finding golang.org/x/lint latest
go: finding golang.org/x/tools latest
=== cyclomatic complexity ===
go: finding github.com/fzipp/gocyclo latest
57 assertion isMatch assertion/match.go:27:1
19 tf12parser (*Parser).getValuesByBlockType linter/tf12parser/parser.go:278:1
16 main main cli/app.go:91:1
WARNING: cyclomatic complexity is high
=== testing Terraform Built In Rules ===
=== RUN   TestTerraformBuiltInRules
--- PASS: TestTerraformBuiltInRules (0.09s)
PASS
ok      github.com/stelligent/config-lint/cli   0.106s
```
