### PR TITLE
adding rule and test cases for aws_redshift_parameter_group require_ssl parameter

### DIFF
--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -873,6 +873,24 @@ rules:
     tags:
       - redshift
 
+  - id: REDSHIFT_CLUSTER_PARAMETER_GROUP_REQUIRE_SSL
+    message: RedshiftCluster Parameter Group should set require_ssl to true
+    resource: aws_redshift_parameter_group
+    severity: WARNING
+    assertions:
+      - key: parameter
+        op: present
+      - every:
+          key: parameter
+          expressions:
+            - key: name
+              op: eq
+              value: require_ssl
+            - key: value
+              op: is-true
+    tags:
+      - redshift
+
   - id: S3_BUCKET_OBJECT_ENCRYPTION
     message: S3 Bucket Object should be encrypted
     resource: aws_s3_bucket_object

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -106,6 +106,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"kinesis.tf", "KINESIS_FIREHOSE_DELIVERY_STREAM_ENCRYPTION", 0, 1},
 		{"redshift_encryption.tf", "REDSHIFT_CLUSTER_ENCRYPTION", 0, 2},
 		{"redshift_kms.tf", "REDSHIFT_CLUSTER_KMS_KEY_ID", 1, 0},
+		{"redshift_parameter_group_require_ssl.tf", "REDSHIFT_CLUSTER_PARAMETER_GROUP_REQUIRE_SSL", 2, 0},
 		{"ecs.tf", "ECS_ENVIRONMENT_SECRETS", 0, 1},
 	}
 	for _, tc := range testCases {

--- a/cli/testdata/builtin/terraform/redshift_parameter_group_require_ssl.tf
+++ b/cli/testdata/builtin/terraform/redshift_parameter_group_require_ssl.tf
@@ -1,0 +1,27 @@
+# Warn
+resource "aws_redshift_parameter_group" "parameter_and_require_ssl_not_set" {
+  name   = "foobar"
+  family = "redshift-1.0"
+}
+
+# Warn
+resource "aws_redshift_parameter_group" "require_ssl_set_to_false" {
+  name   = "foobar"
+  family = "redshift-1.0"
+
+  parameter {
+    name  = "require_ssl"
+    value = "false"
+  }
+}
+
+# Pass
+resource "aws_redshift_parameter_group" "require_ssl_set_to_true" {
+  name   = "foobar"
+  family = "redshift-1.0"
+
+  parameter {
+    name  = "require_ssl"
+    value = "true"
+  }
+}


### PR DESCRIPTION
Closes #88 

Creates a **WARNING** rule and corresponding tests to ensure the `aws_redshift_parameter_group` resource has a `parameter` array AND that the setting `require_ssl` equals `true`

``` bash
make testtf
=== generating ===
=== linting ===
go: finding golang.org/x/lint latest
go: finding golang.org/x/tools latest
=== cyclomatic complexity ===
go: finding github.com/fzipp/gocyclo latest
57 assertion isMatch assertion/match.go:27:1
19 tf12parser (*Parser).getValuesByBlockType linter/tf12parser/parser.go:278:1
16 main main cli/app.go:91:1
WARNING: cyclomatic complexity is high
=== testing Terraform Built In Rules ===
=== RUN   TestTerraformBuiltInRules
--- PASS: TestTerraformBuiltInRules (0.10s)
PASS
ok      github.com/stelligent/config-lint/cli   0.114s
```
