### PR TITLE
Feature/108 redshift cluster logging rule

### DIFF
--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -873,6 +873,16 @@ rules:
     tags:
       - redshift
 
+  - id: REDSHIFT_CLUSTER_AUDIT_LOGGING
+    message: RedshiftCluster should have audit logging enabled
+    resource: aws_redshift_cluster
+    severity: WARNING
+    assertions:
+      - key: logging.enable
+        op: is-true
+    tags:
+      - redshift
+
   - id: S3_BUCKET_OBJECT_ENCRYPTION
     message: S3 Bucket Object should be encrypted
     resource: aws_s3_bucket_object

--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -878,8 +878,13 @@ rules:
     resource: aws_redshift_cluster
     severity: WARNING
     assertions:
-      - key: logging.enable
-        op: is-true
+      - key: logging
+        op: present
+      - every:
+          key: logging
+          expressions:
+            - key: enable
+              op: is-true
     tags:
       - redshift
 

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -106,7 +106,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"kinesis.tf", "KINESIS_FIREHOSE_DELIVERY_STREAM_ENCRYPTION", 0, 1},
 		{"redshift_encryption.tf", "REDSHIFT_CLUSTER_ENCRYPTION", 0, 2},
 		{"redshift_kms.tf", "REDSHIFT_CLUSTER_KMS_KEY_ID", 1, 0},
-		{"redshift_logging.tf", "REDSHIFT_CLUSTER_AUDIT_LOGGING", 0, 0}, // TODO: fix Warning count
+		{"redshift_logging.tf", "REDSHIFT_CLUSTER_AUDIT_LOGGING", 2, 0},
 		{"ecs.tf", "ECS_ENVIRONMENT_SECRETS", 0, 1},
 	}
 	for _, tc := range testCases {

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -106,6 +106,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"kinesis.tf", "KINESIS_FIREHOSE_DELIVERY_STREAM_ENCRYPTION", 0, 1},
 		{"redshift_encryption.tf", "REDSHIFT_CLUSTER_ENCRYPTION", 0, 2},
 		{"redshift_kms.tf", "REDSHIFT_CLUSTER_KMS_KEY_ID", 1, 0},
+		{"redshift_logging.tf", "REDSHIFT_CLUSTER_AUDIT_LOGGING", 0, 0}, // TODO: fix Warning count
 		{"ecs.tf", "ECS_ENVIRONMENT_SECRETS", 0, 1},
 	}
 	for _, tc := range testCases {

--- a/cli/testdata/builtin/terraform/redshift_logging.tf
+++ b/cli/testdata/builtin/terraform/redshift_logging.tf
@@ -6,34 +6,34 @@ variable "kms_key_arn" {
 resource "aws_s3_bucket" "audit_logs" {}
 
 
-# # Warn
-# resource "aws_redshift_cluster" "logging_not_set" {
-#   cluster_identifier = "my-redshift-cluster"
-#   database_name      = "mydb"
-#   master_username    = "admin"
-#   master_password    = "foobarbaz"
-#   node_type          = "dc2.large"
-#   cluster_type       = "single-node"
-#   encrypted          = true
-#   kms_key_id         = "arn:aws:kms:us-east-1:1234567890:key/foobar"
-# }
+# Warn
+resource "aws_redshift_cluster" "logging_not_set" {
+  cluster_identifier = "my-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "admin"
+  master_password    = "foobarbaz"
+  node_type          = "dc2.large"
+  cluster_type       = "single-node"
+  encrypted          = true
+  kms_key_id         = "arn:aws:kms:us-east-1:1234567890:key/foobar"
+}
 
-# # Warn
-# resource "aws_redshift_cluster" "logging_is_disabled" {
-#   cluster_identifier = "my-redshift-cluster"
-#   database_name      = "mydb"
-#   master_username    = "admin"
-#   master_password    = "foobarbaz"
-#   node_type          = "dc2.large"
-#   cluster_type       = "single-node"
-#   encrypted          = true
-#   kms_key_id         = "${var.kms_key_arn}"
-#   logging {
-#     enable        = false
-#     bucket_name   = "${aws_s3_bucket.audit_logs.id}"
-#     s3_key_prefix = "aws_redshift_cluster"
-#   }
-# }
+# Warn
+resource "aws_redshift_cluster" "logging_is_disabled" {
+  cluster_identifier = "my-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "admin"
+  master_password    = "foobarbaz"
+  node_type          = "dc2.large"
+  cluster_type       = "single-node"
+  encrypted          = true
+  kms_key_id         = "${var.kms_key_arn}"
+  logging {
+    enable        = false
+    bucket_name   = "${aws_s3_bucket.audit_logs.id}"
+    s3_key_prefix = "aws_redshift_cluster"
+  }
+}
 
 # Pass
 resource "aws_redshift_cluster" "logging_is_enabled" {
@@ -45,7 +45,6 @@ resource "aws_redshift_cluster" "logging_is_enabled" {
   cluster_type       = "single-node"
   encrypted          = true
   kms_key_id         = "${var.kms_key_arn}"
-  enable             = false
   logging {
     enable        = true
     bucket_name   = "${aws_s3_bucket.audit_logs.id}"

--- a/cli/testdata/builtin/terraform/redshift_logging.tf
+++ b/cli/testdata/builtin/terraform/redshift_logging.tf
@@ -1,0 +1,54 @@
+# Setup
+variable "kms_key_arn" {
+  default = "arn:aws:kms:us-east-1:1234567890:key/foobar"
+}
+
+resource "aws_s3_bucket" "audit_logs" {}
+
+
+# # Warn
+# resource "aws_redshift_cluster" "logging_not_set" {
+#   cluster_identifier = "my-redshift-cluster"
+#   database_name      = "mydb"
+#   master_username    = "admin"
+#   master_password    = "foobarbaz"
+#   node_type          = "dc2.large"
+#   cluster_type       = "single-node"
+#   encrypted          = true
+#   kms_key_id         = "arn:aws:kms:us-east-1:1234567890:key/foobar"
+# }
+
+# # Warn
+# resource "aws_redshift_cluster" "logging_is_disabled" {
+#   cluster_identifier = "my-redshift-cluster"
+#   database_name      = "mydb"
+#   master_username    = "admin"
+#   master_password    = "foobarbaz"
+#   node_type          = "dc2.large"
+#   cluster_type       = "single-node"
+#   encrypted          = true
+#   kms_key_id         = "${var.kms_key_arn}"
+#   logging {
+#     enable        = false
+#     bucket_name   = "${aws_s3_bucket.audit_logs.id}"
+#     s3_key_prefix = "aws_redshift_cluster"
+#   }
+# }
+
+# Pass
+resource "aws_redshift_cluster" "logging_is_enabled" {
+  cluster_identifier = "my-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "admin"
+  master_password    = "foobarbaz"
+  node_type          = "dc2.large"
+  cluster_type       = "single-node"
+  encrypted          = true
+  kms_key_id         = "${var.kms_key_arn}"
+  enable             = false
+  logging {
+    enable        = true
+    bucket_name   = "${aws_s3_bucket.audit_logs.id}"
+    s3_key_prefix = "aws_redshift_cluster"
+  }
+}


### PR DESCRIPTION
Closes #108 

Creates a **WARNING** rule and corresponding tests to ensure the `aws_redshift_cluster` resource has a `logging` array AND that the setting `enable` equals `true`

``` bash
make testtf
=== generating ===
=== linting ===
go: finding golang.org/x/lint latest
go: finding golang.org/x/tools latest
=== cyclomatic complexity ===
go: finding github.com/fzipp/gocyclo latest
57 assertion isMatch assertion/match.go:27:1
19 tf12parser (*Parser).getValuesByBlockType linter/tf12parser/parser.go:278:1
16 main main cli/app.go:91:1
WARNING: cyclomatic complexity is high
=== testing Terraform Built In Rules ===
=== RUN   TestTerraformBuiltInRules
--- PASS: TestTerraformBuiltInRules (0.09s)
PASS
ok      github.com/stelligent/config-lint/cli   0.102s
```
