### PR TITLE
feature/123_elb_rules_and_tests

### DIFF
--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -370,17 +370,21 @@ rules:
     assertions:
       # Check if 'access_logs' is present and if it is then we can check to see if the 
       # key 'enabled' exists within the 'access_logs' array.
-      # If it does NOT exist, then the value is True by default and therefor should be allowed.
-      # If it does exist, the only allowed value type is Boolean, so a string such as 'foo'
-      # can't match the value return for key 'enabled'. We then check to see if the value for
-      # the key 'enabled' is set to True
+      # If it does NOT exist, then the value is True by default.
+      # If it does exist, then the value should be set to True.
       - key: access_logs
         op: present
-      - every:
-          key: "access_logs[?enabled!=foo]"
-          expressions:
-            - key: enabled
-              op: is-true
+      - or:
+        - every:
+            key: access_logs[]
+            expressions:
+              - key: enabled
+                op: absent
+        - every:
+            key: access_logs[]
+            expressions:
+              - key: enabled
+                op: is-true
     tags:
       - elb
 

--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -368,8 +368,19 @@ rules:
     resource: aws_elb
     severity: WARNING
     assertions:
+      # Check if 'access_logs' is present and if it is then we can check to see if the 
+      # key 'enabled' exists within the 'access_logs' array.
+      # If it does NOT exist, then the value is True by default and therefor should be allowed.
+      # If it does exist, the only allowed value type is Boolean, so a string such as 'foo'
+      # can't match the value return for key 'enabled'. We then check to see if the value for
+      # the key 'enabled' is set to True
       - key: access_logs
         op: present
+      - every:
+          key: "access_logs[?enabled!=foo]"
+          expressions:
+            - key: enabled
+              op: is-true
     tags:
       - elb
 

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -75,7 +75,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"aws/iam_policy/policy_version.tf", "POLICY_VERSION", 0, 1},
 		{"aws/iam_role_policy/policy_version.tf", "POLICY_VERSION", 0, 1},
 		{"aws/iam_role/assume_role_policy_version.tf", "ASSUME_ROLEPOLICY_VERSION", 0, 1},
-		{"aws/elb.tf", "ELB_ACCESS_LOGGING", 1, 0},
+		{"aws/elb/access_logs_enabled.tf", "ELB_ACCESS_LOGGING", 2, 0},
 		{"aws/s3.tf", "S3_BUCKET_ACL", 0, 0},
 		{"aws/s3.tf", "S3_NOT_ACTION", 0, 0},
 		{"aws/s3.tf", "S3_NOT_PRINCIPAL", 0, 0},

--- a/cli/testdata/builtin/terraform/aws/elb/access_logs_enabled.tf
+++ b/cli/testdata/builtin/terraform/aws/elb/access_logs_enabled.tf
@@ -1,0 +1,83 @@
+# Pass
+resource "aws_elb" "access_logs_set" {
+  availability_zones = [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c"
+  ]
+
+  access_logs {
+    bucket        = "foo"
+    bucket_prefix = "bar"
+    interval      = 60
+  }
+
+  listener {
+    instance_port     = 8000
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+}
+
+# Pass
+resource "aws_elb" "access_logs_enabled" {
+  availability_zones = [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c"
+  ]
+
+  access_logs {
+    bucket        = "foo"
+    bucket_prefix = "bar"
+    interval      = 60
+    enabled       = true
+  }
+
+  listener {
+    instance_port     = 8000
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+}
+
+# Warn
+resource "aws_elb" "access_logs_not_set" {
+  availability_zones = [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c"
+  ]
+
+  listener {
+    instance_port     = 8000
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+}
+
+# Warn
+resource "aws_elb" "access_logs_disabled" {
+  availability_zones = [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c"
+  ]
+
+  access_logs {
+    bucket        = "foo"
+    bucket_prefix = "bar"
+    interval      = 60
+    enabled       = false
+  }
+
+  listener {
+    instance_port     = 8000
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+}


### PR DESCRIPTION
Partial for #123 

This covers the ELB rule for Terraform11.

* Adds further checking for the `ELB_ACCESS_LOGGING` rule to ensure that `access_logs` is present **AND** that **IF** `enabled` is stated, then it should be set to `True`
* Creates tests to validate entire rule