### PR TITLE
Feature/123 s3 rules and tests

### DIFF
--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -975,8 +975,11 @@ rules:
     resource: aws_s3_bucket_object
     severity: FAILURE
     assertions:
-      - key: kms_key_id
-        op: present
+      - or:
+        - key: kms_key_id
+          op: present
+        - key: server_side_encryption
+          op: present
     tags:
       - s3
 

--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -443,9 +443,9 @@ rules:
       - s3
 
   - id: S3_BUCKET_POLICY_WILDCARD_ACTION
-    message: Should not use wildcard Principal in S3 bucket policy
+    message: Should not use wildcard Action in an Allow S3 bucket policy
     resource: aws_s3_bucket_policy
-    severity: WARNING
+    severity: FAILURE
     assertions:
       - none:
           key: policy.Statement[]

--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -464,14 +464,14 @@ rules:
     resource: aws_s3_bucket_policy
     severity: FAILURE
     assertions:
-      - some:
+      - none:
           key: policy.Statement[]
           expressions:
             - key: Effect
               op: eq
               value: Allow
             - key: Condition.Bool."aws:SecureTransport"
-              op: is-true
+              op: is-false
     tags:
       - s3
 

--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -426,9 +426,9 @@ rules:
       - s3
 
   - id: S3_BUCKET_POLICY_WILDCARD_PRINCIPAL
-    message: Should not use wildcard principal in S3 bucket policy
+    message: Should not use wildcard Principal in an Allow S3 bucket policy
     resource: aws_s3_bucket_policy
-    severity: WARNING
+    severity: FAILURE
     assertions:
       - none:
           key: policy.Statement[]

--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -410,6 +410,7 @@ rules:
             - key: NotAction
               op: present
     tags:
+      - policy
       - s3
 
   - id: S3_NOT_PRINCIPAL
@@ -423,6 +424,7 @@ rules:
             - key: NotPrincipal
               op: present
     tags:
+      - policy
       - s3
 
   - id: S3_BUCKET_POLICY_WILDCARD_PRINCIPAL
@@ -440,6 +442,7 @@ rules:
               op: contains
               value: "*"
     tags:
+      - policy
       - s3
 
   - id: S3_BUCKET_POLICY_WILDCARD_ACTION
@@ -457,6 +460,7 @@ rules:
               op: contains
               value: "*"
     tags:
+      - policy
       - s3
 
   - id: S3_BUCKET_POLICY_ONLY_HTTPS
@@ -473,6 +477,7 @@ rules:
             - key: Condition.Bool."aws:SecureTransport"
               op: is-false
     tags:
+      - policy
       - s3
 
   - id: S3_BUCKET_ENCRYPTION
@@ -1039,6 +1044,7 @@ rules:
         value: "2012-10-17"
     tags:
       - iam
+      - policy
 
   - id: ASSUME_ROLEPOLICY_VERSION
     message: Version in IAM Policy should be 2012-10-17
@@ -1050,6 +1056,7 @@ rules:
         value: "2012-10-17"
     tags:
       - iam
+      - policy
 
   - id: BATCH_DEFINITION_PRIVILEGED
     message: Batch Job Definition Container Properties should not have Privileged set to true

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -76,7 +76,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"aws/iam_role_policy/policy_version.tf", "POLICY_VERSION", 0, 1},
 		{"aws/iam_role/assume_role_policy_version.tf", "ASSUME_ROLEPOLICY_VERSION", 0, 1},
 		{"aws/elb/access_logs_enabled.tf", "ELB_ACCESS_LOGGING", 2, 0},
-		{"aws/s3.tf", "S3_BUCKET_ACL", 0, 0},
+		{"aws/s3_bucket/acl_not_public.tf", "S3_BUCKET_ACL", 0, 2},
 		{"aws/s3.tf", "S3_NOT_ACTION", 0, 0},
 		{"aws/s3.tf", "S3_NOT_PRINCIPAL", 0, 0},
 		{"aws/s3_bucket_policy/policy_version.tf", "POLICY_VERSION", 0, 1},

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -80,7 +80,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"aws/s3_bucket_policy/policy_statement_notaction.tf", "S3_NOT_ACTION", 1, 0},
 		{"aws/s3_bucket_policy/policy_statement_notprincipal.tf", "S3_NOT_PRINCIPAL", 1, 0},
 		{"aws/s3_bucket_policy/policy_version.tf", "POLICY_VERSION", 0, 1},
-		{"aws/s3.tf", "S3_BUCKET_POLICY_WILDCARD_PRINCIPAL", 1, 0},
+		{"aws/s3_bucket_policy/policy_statement_principal_wildcard.tf", "S3_BUCKET_POLICY_WILDCARD_PRINCIPAL", 0, 1},
 		{"aws/s3.tf", "S3_BUCKET_POLICY_WILDCARD_ACTION", 1, 0},
 		{"aws/s3.tf", "S3_BUCKET_ENCRYPTION", 0, 1},
 		{"aws/s3.tf", "S3_BUCKET_OBJECT_ENCRYPTION", 0, 1},

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -77,7 +77,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"aws/iam_role/assume_role_policy_version.tf", "ASSUME_ROLEPOLICY_VERSION", 0, 1},
 		{"aws/elb/access_logs_enabled.tf", "ELB_ACCESS_LOGGING", 2, 0},
 		{"aws/s3_bucket/acl_not_public.tf", "S3_BUCKET_ACL", 0, 2},
-		{"aws/s3.tf", "S3_NOT_ACTION", 0, 0},
+		{"aws/s3_bucket_policy/policy_statement_notaction.tf", "S3_NOT_ACTION", 1, 0},
 		{"aws/s3.tf", "S3_NOT_PRINCIPAL", 0, 0},
 		{"aws/s3_bucket_policy/policy_version.tf", "POLICY_VERSION", 0, 1},
 		{"aws/s3.tf", "S3_BUCKET_POLICY_WILDCARD_PRINCIPAL", 1, 0},

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -83,7 +83,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"aws/s3_bucket_policy/policy_statement_principal_wildcard.tf", "S3_BUCKET_POLICY_WILDCARD_PRINCIPAL", 0, 1},
 		{"aws/s3_bucket_policy/policy_statement_action_wildcard.tf", "S3_BUCKET_POLICY_WILDCARD_ACTION", 0, 1},
 		{"aws/s3_bucket_policy/policy_statement_secure_transport.tf", "S3_BUCKET_POLICY_ONLY_HTTPS", 0, 1},
-		{"aws/s3.tf", "S3_BUCKET_ENCRYPTION", 0, 1},
+		{"aws/s3_bucket/server_side_encryption_enabled.tf", "S3_BUCKET_ENCRYPTION", 0, 1},
 		{"aws/s3.tf", "S3_BUCKET_OBJECT_ENCRYPTION", 0, 1},
 		{"aws/sns_topic_policy/policy_version.tf", "POLICY_VERSION", 0, 1},
 		{"aws/sns.tf", "SNS_TOPIC_POLICY_WILDCARD_PRINCIPAL", 1, 0},

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -78,7 +78,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"aws/elb/access_logs_enabled.tf", "ELB_ACCESS_LOGGING", 2, 0},
 		{"aws/s3_bucket/acl_not_public.tf", "S3_BUCKET_ACL", 0, 2},
 		{"aws/s3_bucket_policy/policy_statement_notaction.tf", "S3_NOT_ACTION", 1, 0},
-		{"aws/s3.tf", "S3_NOT_PRINCIPAL", 0, 0},
+		{"aws/s3_bucket_policy/policy_statement_notprincipal.tf", "S3_NOT_PRINCIPAL", 1, 0},
 		{"aws/s3_bucket_policy/policy_version.tf", "POLICY_VERSION", 0, 1},
 		{"aws/s3.tf", "S3_BUCKET_POLICY_WILDCARD_PRINCIPAL", 1, 0},
 		{"aws/s3.tf", "S3_BUCKET_POLICY_WILDCARD_ACTION", 1, 0},

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -81,7 +81,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"aws/s3_bucket_policy/policy_statement_notprincipal.tf", "S3_NOT_PRINCIPAL", 1, 0},
 		{"aws/s3_bucket_policy/policy_version.tf", "POLICY_VERSION", 0, 1},
 		{"aws/s3_bucket_policy/policy_statement_principal_wildcard.tf", "S3_BUCKET_POLICY_WILDCARD_PRINCIPAL", 0, 1},
-		{"aws/s3.tf", "S3_BUCKET_POLICY_WILDCARD_ACTION", 1, 0},
+		{"aws/s3_bucket_policy/policy_statement_action_wildcard.tf", "S3_BUCKET_POLICY_WILDCARD_ACTION", 0, 1},
 		{"aws/s3.tf", "S3_BUCKET_ENCRYPTION", 0, 1},
 		{"aws/s3.tf", "S3_BUCKET_OBJECT_ENCRYPTION", 0, 1},
 		{"aws/sns_topic_policy/policy_version.tf", "POLICY_VERSION", 0, 1},

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -82,6 +82,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"aws/s3_bucket_policy/policy_version.tf", "POLICY_VERSION", 0, 1},
 		{"aws/s3_bucket_policy/policy_statement_principal_wildcard.tf", "S3_BUCKET_POLICY_WILDCARD_PRINCIPAL", 0, 1},
 		{"aws/s3_bucket_policy/policy_statement_action_wildcard.tf", "S3_BUCKET_POLICY_WILDCARD_ACTION", 0, 1},
+		{"aws/s3_bucket_policy/policy_statement_secure_transport.tf", "S3_BUCKET_POLICY_ONLY_HTTPS", 0, 1},
 		{"aws/s3.tf", "S3_BUCKET_ENCRYPTION", 0, 1},
 		{"aws/s3.tf", "S3_BUCKET_OBJECT_ENCRYPTION", 0, 1},
 		{"aws/sns_topic_policy/policy_version.tf", "POLICY_VERSION", 0, 1},

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -84,7 +84,7 @@ func TestTerraformBuiltInRules(t *testing.T) {
 		{"aws/s3_bucket_policy/policy_statement_action_wildcard.tf", "S3_BUCKET_POLICY_WILDCARD_ACTION", 0, 1},
 		{"aws/s3_bucket_policy/policy_statement_secure_transport.tf", "S3_BUCKET_POLICY_ONLY_HTTPS", 0, 1},
 		{"aws/s3_bucket/server_side_encryption_enabled.tf", "S3_BUCKET_ENCRYPTION", 0, 1},
-		{"aws/s3.tf", "S3_BUCKET_OBJECT_ENCRYPTION", 0, 1},
+		{"aws/s3_bucket_object/encryption_enabled.tf", "S3_BUCKET_OBJECT_ENCRYPTION", 0, 1},
 		{"aws/sns_topic_policy/policy_version.tf", "POLICY_VERSION", 0, 1},
 		{"aws/sns.tf", "SNS_TOPIC_POLICY_WILDCARD_PRINCIPAL", 1, 0},
 		{"aws/sns.tf", "SNS_TOPIC_POLICY_NOT_ACTION", 0, 0},

--- a/cli/testdata/builtin/terraform/aws/s3_bucket/acl_not_public.tf
+++ b/cli/testdata/builtin/terraform/aws/s3_bucket/acl_not_public.tf
@@ -1,0 +1,43 @@
+# Pass
+resource "aws_s3_bucket" "acl_not_set" {
+}
+
+# Pass
+resource "aws_s3_bucket" "acl_set_to_private" {
+  acl = "private"
+}
+
+# Pass
+resource "aws_s3_bucket" "acl_set_to_aws-exec-read" {
+  acl = "aws-exec-read"
+}
+
+# Pass
+resource "aws_s3_bucket" "acl_set_to_authenticated-read" {
+  acl = "authenticated-read"
+}
+
+# Pass
+resource "aws_s3_bucket" "acl_set_to_bucket-owner-read" {
+  acl = "bucket-owner-read"
+}
+
+# Pass
+resource "aws_s3_bucket" "acl_set_to_bucket-owner-full-control" {
+  acl = "bucket-owner-full-control"
+}
+
+# Pass
+resource "aws_s3_bucket" "acl_set_to_log-delivery-write" {
+  acl = "log-delivery-write"
+}
+
+# Fail
+resource "aws_s3_bucket" "acl_set_to_public-read" {
+  acl = "public-read"
+}
+
+# Fail
+resource "aws_s3_bucket" "acl_set_to_public-read-write" {
+  acl = "public-read-write"
+}

--- a/cli/testdata/builtin/terraform/aws/s3_bucket/server_side_encryption_enabled.tf
+++ b/cli/testdata/builtin/terraform/aws/s3_bucket/server_side_encryption_enabled.tf
@@ -1,0 +1,19 @@
+# Setup Helper
+resource "aws_kms_key" "test_key" {
+}
+
+# Pass
+resource "aws_s3_bucket" "server_side_encryption_configuration_set" {
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = "${aws_kms_key.test_key.arn}"
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+}
+
+# Fail
+resource "aws_s3_bucket" "server_side_encryption_configuration_not_set" {
+}

--- a/cli/testdata/builtin/terraform/aws/s3_bucket_object/encryption_enabled.tf
+++ b/cli/testdata/builtin/terraform/aws/s3_bucket_object/encryption_enabled.tf
@@ -1,0 +1,34 @@
+## Setup Helper
+resource "aws_kms_key" "test_key" {
+}
+
+resource "aws_s3_bucket" "test_bucket" {
+  acl = "private"
+}
+
+# Pass
+resource "aws_s3_bucket_object" "encrypt_with_kms_key_id" {
+  key        = "foo"
+  bucket     = "${aws_s3_bucket.test_bucket.id}"
+  kms_key_id = "${aws_kms_key.test_key.arn}"
+}
+
+# Pass
+resource "aws_s3_bucket_object" "encrypt_with_server_side_encryption_s3_default_master_key" {
+  key                    = "foo"
+  bucket                 = "${aws_s3_bucket.test_bucket.id}"
+  server_side_encryption = "aws:kms"
+}
+
+# Pass
+resource "aws_s3_bucket_object" "encrypt_with_server_side_encryption_aws_managed_key" {
+  key                    = "foo"
+  bucket                 = "${aws_s3_bucket.test_bucket.id}"
+  server_side_encryption = "AES256"
+}
+
+# Fail
+resource "aws_s3_bucket_object" "encryption_method_not_set" {
+  key    = "foo"
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+}

--- a/cli/testdata/builtin/terraform/aws/s3_bucket_policy/policy_statement_action_wildcard.tf
+++ b/cli/testdata/builtin/terraform/aws/s3_bucket_policy/policy_statement_action_wildcard.tf
@@ -1,0 +1,75 @@
+## Setup Helper
+resource "aws_s3_bucket" "test_bucket" {
+}
+
+# Pass
+resource "aws_s3_bucket_policy" "policy_statement_allow_action_without_wildcard" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::fooBucket/*"
+    }
+  ]
+}
+EOF
+}
+
+# Pass
+resource "aws_s3_bucket_policy" "policy_statement_deny_action_without_wildcard" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::fooBucket/*"
+    }
+  ]
+}
+EOF
+}
+
+# Pass
+resource "aws_s3_bucket_policy" "policy_statement_deny_action_with_wildcard" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      "Action": "s3:Get*",
+      "Resource": "arn:aws:s3:::fooBucket/*"
+    }
+  ]
+}
+EOF
+}
+
+# Fail
+resource "aws_s3_bucket_policy" "policy_statement_allow_action_with_wildcard" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:Get*",
+      "Resource": "arn:aws:s3:::fooBucket/*"
+    }
+  ]
+}
+EOF
+}

--- a/cli/testdata/builtin/terraform/aws/s3_bucket_policy/policy_statement_notaction.tf
+++ b/cli/testdata/builtin/terraform/aws/s3_bucket_policy/policy_statement_notaction.tf
@@ -1,0 +1,39 @@
+## Setup Helper
+resource "aws_s3_bucket" "test_bucket" {
+}
+
+# Pass
+resource "aws_s3_bucket_policy" "policy_statement_without_notaction" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::fooBucket/*"
+    }
+  ]
+}
+EOF
+}
+
+# Fail
+resource "aws_s3_bucket_policy" "policy_statement_with_notaction" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "NotAction": "s3:GetObject",
+      "Resource": "arn:aws:s3:::fooBucket/*"
+    }
+  ]
+}
+EOF
+}

--- a/cli/testdata/builtin/terraform/aws/s3_bucket_policy/policy_statement_notprincipal.tf
+++ b/cli/testdata/builtin/terraform/aws/s3_bucket_policy/policy_statement_notprincipal.tf
@@ -1,0 +1,51 @@
+## Setup Helper
+resource "aws_s3_bucket" "test_bucket" {
+}
+
+# Pass
+resource "aws_s3_bucket_policy" "policy_statement_without_notprincipal" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::1234567890:user/foo"
+        ]
+      },
+
+      "Resource": "arn:aws:s3:::fooBucket/*"
+    }
+  ]
+}
+EOF
+}
+
+# Fail
+resource "aws_s3_bucket_policy" "policy_statement_with_notprincipal" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "NotPrincipal": {
+        "AWS": [
+          "arn:aws:iam::1234567890:user/foo"
+        ]
+      },
+      "Resource": "arn:aws:s3:::fooBucket/*"
+    }
+  ]
+}
+EOF
+}
+

--- a/cli/testdata/builtin/terraform/aws/s3_bucket_policy/policy_statement_principal_wildcard.tf
+++ b/cli/testdata/builtin/terraform/aws/s3_bucket_policy/policy_statement_principal_wildcard.tf
@@ -1,0 +1,95 @@
+## Setup Helper
+resource "aws_s3_bucket" "test_bucket" {
+}
+
+# Pass
+resource "aws_s3_bucket_policy" "policy_statement_allow_principal_without_wildcard" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::1234567890:user/foo"
+        ]
+      },
+      "Resource": "arn:aws:s3:::fooBucket/*"
+    }
+  ]
+}
+EOF
+}
+
+# Pass
+resource "aws_s3_bucket_policy" "policy_statement_deny_principal_without_wildcard" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      "Action": "s3:GetObject",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::1234567890:user/foo"
+        ]
+      },
+      "Resource": "arn:aws:s3:::fooBucket/*"
+    }
+  ]
+}
+EOF
+}
+
+# Pass
+resource "aws_s3_bucket_policy" "policy_statement_deny_principal_with_wildcard" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      "Action": "s3:GetObject",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::1234567890:user/foo*"
+        ]
+      },
+      "Resource": "arn:aws:s3:::fooBucket/*"
+    }
+  ]
+}
+EOF
+}
+
+# Fail
+resource "aws_s3_bucket_policy" "policy_statement_allow_principal_with_wildcard" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::1234567890:user/foo*"
+        ]
+      },
+      "Resource": "arn:aws:s3:::fooBucket/*"
+    }
+  ]
+}
+EOF
+}

--- a/cli/testdata/builtin/terraform/aws/s3_bucket_policy/policy_statement_secure_transport.tf
+++ b/cli/testdata/builtin/terraform/aws/s3_bucket_policy/policy_statement_secure_transport.tf
@@ -1,0 +1,107 @@
+## Setup Helper
+resource "aws_s3_bucket" "test_bucket" {
+}
+
+# Pass
+resource "aws_s3_bucket_policy" "policy_statement_allow_condition_SecureTransport_set_to_true" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": [
+        "arn:aws:s3:::fooBucket/*"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "true"
+        }
+      },
+      "Principal": "*"
+    }
+  ]
+}
+EOF
+}
+
+# Pass
+resource "aws_s3_bucket_policy" "policy_statement_deny_condition_SecureTransport_set_to_true" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      "Action": "s3:GetObject",
+      "Resource": [
+        "arn:aws:s3:::fooBucket/*"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "true"
+        }
+      },
+      "Principal": "*"
+    }
+  ]
+}
+EOF
+}
+
+# Pass
+resource "aws_s3_bucket_policy" "policy_statement_deny_condition_SecureTransport_set_to_false" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      "Action": "s3:GetObject",
+      "Resource": [
+        "arn:aws:s3:::fooBucket/*"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      },
+      "Principal": "*"
+    }
+  ]
+}
+EOF
+}
+
+# Fail
+resource "aws_s3_bucket_policy" "policy_statement_allow_condition_SecureTransport_set_to_false" {
+  bucket = "${aws_s3_bucket.test_bucket.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": [
+        "arn:aws:s3:::fooBucket/*"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      },
+      "Principal": "*"
+    }
+  ]
+}
+EOF
+}

--- a/go.mod
+++ b/go.mod
@@ -25,5 +25,5 @@ require (
 	golang.org/x/crypto v0.0.0-20200214034016-1d94cc7ab1c6 // indirect
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/sys v0.0.0-20200217220822-9197077df867 // indirect
-	golang.org/x/tools v0.0.0-20200218205902-f8e42dc47720 // indirect
+	golang.org/x/tools v0.0.0-20200219195521-7c4b6277d74d // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -25,5 +25,5 @@ require (
 	golang.org/x/crypto v0.0.0-20200214034016-1d94cc7ab1c6 // indirect
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/sys v0.0.0-20200217220822-9197077df867 // indirect
-	golang.org/x/tools v0.0.0-20200219203042-77adbdfd2c36 // indirect
+	golang.org/x/tools v0.0.0-20200219211314-d3d48f09aa81 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -25,5 +25,5 @@ require (
 	golang.org/x/crypto v0.0.0-20200214034016-1d94cc7ab1c6 // indirect
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/sys v0.0.0-20200217220822-9197077df867 // indirect
-	golang.org/x/tools v0.0.0-20200219195521-7c4b6277d74d // indirect
+	golang.org/x/tools v0.0.0-20200219203042-77adbdfd2c36 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -492,6 +492,8 @@ golang.org/x/tools v0.0.0-20200218205902-f8e42dc47720 h1:90L2fHeLQmQFe04F648NKZE
 golang.org/x/tools v0.0.0-20200218205902-f8e42dc47720/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200219195521-7c4b6277d74d h1:ZQ18He7VORO2x4IEBuwfdp56K+ftEzRjvL0cFuCGCcM=
 golang.org/x/tools v0.0.0-20200219195521-7c4b6277d74d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200219203042-77adbdfd2c36 h1:BCZjrbHHQTu+xrwLsm/PiTuyEPgFnl82o2AGXB36sH4=
+golang.org/x/tools v0.0.0-20200219203042-77adbdfd2c36/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/go.sum
+++ b/go.sum
@@ -494,6 +494,8 @@ golang.org/x/tools v0.0.0-20200219195521-7c4b6277d74d h1:ZQ18He7VORO2x4IEBuwfdp5
 golang.org/x/tools v0.0.0-20200219195521-7c4b6277d74d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200219203042-77adbdfd2c36 h1:BCZjrbHHQTu+xrwLsm/PiTuyEPgFnl82o2AGXB36sH4=
 golang.org/x/tools v0.0.0-20200219203042-77adbdfd2c36/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200219211314-d3d48f09aa81 h1:rHjptmxnKy58RQ6SLKtBl0aRmpTSEMJqbM4GRMlYeUA=
+golang.org/x/tools v0.0.0-20200219211314-d3d48f09aa81/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/go.sum
+++ b/go.sum
@@ -490,6 +490,8 @@ golang.org/x/tools v0.0.0-20200218190056-dc8ced655da2 h1:QkSrkYCPqctY2iLj509pqdb
 golang.org/x/tools v0.0.0-20200218190056-dc8ced655da2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200218205902-f8e42dc47720 h1:90L2fHeLQmQFe04F648NKZE5sQP/M/6CjHcjtM7jP5U=
 golang.org/x/tools v0.0.0-20200218205902-f8e42dc47720/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200219195521-7c4b6277d74d h1:ZQ18He7VORO2x4IEBuwfdp56K+ftEzRjvL0cFuCGCcM=
+golang.org/x/tools v0.0.0-20200219195521-7c4b6277d74d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=


### PR DESCRIPTION
Partial for #123 

This covers the S3 rules for Terraform11.

* Added `policy` tag to necessary rules
* Changed severity level for the following rules:
  * `S3_BUCKET_POLICY_WILDCARD_PRINCIPAL`
  * `S3_BUCKET_POLICY_WILDCARD_ACTION`
* Fixed the `S3_BUCKET_POLICY_ONLY_HTTPS` assertions to work as described
* Added more checks for `S3_BUCKET_OBJECT_ENCRYPTION` rule to ensure all encryption types were checked
* Created tests for each S3 rule and added missing rules to the test list