### PR TITLE
Feature/123 ec2 efs ecs ems elasticache rules

### DIFF
--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -916,8 +916,6 @@ rules:
       - and:
         - key: encrypted
           op: is-true
-        - key: kms_key_id
-          op: present
     tags:
       - efs
 

--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -1031,25 +1031,29 @@ rules:
     message: Environment for ECS task definition should not include AWS secrets
     resource: aws_ecs_task_definition
     severity: FAILURE
+    # this rule fails if it finds a regex match for either the Access Key ID and/or the Secret Access Key
     assertions:
-      - none:
-          key: container_definitions[].environment[]
-          expressions:
-            - or:
+      - not:
+        - some:
+            key: container_definitions[].environment[]
+            expressions:
+              # Check if the string starts with any known 4 character ACCESS_KEY sequence
+              # and is 20 capital alpha-numeric characters long in total
+              - key: value
+                op: regex
+                value: "^(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}$"
+        - some:
+            key: container_definitions[].environment[]
+            expressions:
               - and:
-                - key: name
-                  op: contains
-                  value: KEY
+                # Check if the string is exactly 40 characters long
                 - key: value
                   op: regex
-                  value: "^(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}$"
-              - and:
-                - key: name
-                  op: contains
-                  value: SECRET
+                  value: "^.{40}$"
+                # Check if the string contains only alpha-numeric-slash-plus characters with at least 1 / or +
                 - key: value
                   op: regex
-                  value: "^[A-Za-z0-9/\\+=]{40}$"
+                  value: "^[a-zA-Z0-9/+]+[/+]+[a-zA-Z0-9/+]+$"
     tags:
       - ecs
 

--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -904,8 +904,6 @@ rules:
     assertions:
       - key: encrypted
         op: is-true
-      - key: kms_key_id
-        op: present
     tags:
       - ec2
       - ebs

--- a/cli/assets/terraform.yml
+++ b/cli/assets/terraform.yml
@@ -1140,7 +1140,7 @@ rules:
       - subnet
 
   - id: ELASTICACHE_ENCRYPTION_REST
-    message: ElastiCache ReplicationGroup should have encryption enabled for at rest
+    message: ElastiCache ReplicationGroup should have encryption at rest enabled
     resource: aws_elasticache_replication_group
     severity: FAILURE
     assertions:
@@ -1150,7 +1150,7 @@ rules:
       - elasticache
 
   - id: ELASTICACHE_ENCRYPTION_TRANSIT
-    message: ElastiCache ReplicationGroup should have encryption enabled for in transit
+    message: ElastiCache ReplicationGroup should have encryption in transit enabled
     resource: aws_elasticache_replication_group
     severity: FAILURE
     assertions:

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -169,7 +169,7 @@ func RunTestTerraformBuiltInRules(t *testing.T, terraformVersion string) {
 		{"tf", "aws/redshift/cluster/logging.tf", "REDSHIFT_CLUSTER_AUDIT_LOGGING", 2, 0},
 		{"tf", "aws/redshift/cluster/publicly_accessible.tf", "REDSHIFT_CLUSTER_PUBLICLY_ACCESSIBLE", 0, 2},
 		{"tf", "aws/redshift/parameter_group/require_ssl.tf", "REDSHIFT_CLUSTER_PARAMETER_GROUP_REQUIRE_SSL", 2, 0},
-		{"both", "aws/ecs.tf", "ECS_ENVIRONMENT_SECRETS", 0, 1},
+		{"tf", "aws/ecs_task_definition/secrets.tf", "ECS_ENVIRONMENT_SECRETS", 0, 3},
 	}
 
 	// Run test cases

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -172,6 +172,7 @@ func RunTestTerraformBuiltInRules(t *testing.T, terraformVersion string) {
 		{"tf", "aws/ecs_task_definition/secrets.tf", "ECS_ENVIRONMENT_SECRETS", 0, 3},
 		{"tf", "aws/emr_cluster/logging.tf", "AWS_EMR_CLUSTER_LOGGING", 1, 0},
 		{"tf", "aws/elasticache_replication_group/encryption_at_rest.tf", "ELASTICACHE_ENCRYPTION_REST", 0, 2},
+		{"tf", "aws/elasticache_replication_group/encryption_in_transit.tf", "ELASTICACHE_ENCRYPTION_TRANSIT", 0, 2},
 	}
 
 	// Run test cases

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -150,7 +150,7 @@ func RunTestTerraformBuiltInRules(t *testing.T, terraformVersion string) {
 		{"tf", "aws/lb/access_logs_enabled.tf", "ALB_ACCESS_LOGS", 0, 3},
 		{"tf", "aws/ami/ebs_block_device_encrypted.tf", "AMI_VOLUMES_ENCRYPTED", 0, 2},
 		{"tf", "aws/ami_copy/encrypted.tf", "AMI_COPY_SNAPSHOTS_ENCRYPTED", 0, 2},
-		{"both", "aws/ec2.tf", "EBS_BLOCK_DEVICE_ENCRYPTED", 0, 0},
+		{"tf", "aws/instance/ebs_block_device_encrypted.tf", "EBS_BLOCK_DEVICE_ENCRYPTED", 0, 2},
 		{"both", "aws/ec2.tf", "EBS_VOLUME_ENCRYPTION", 0, 2},
 		{"tf", "aws/cloudtrail/kms_key_id.tf", "CLOUDTRAIL_ENCRYPTION", 1, 0},
 		{"both", "aws/codebuild_project/project_encryption.tf", "CODEBUILD_PROJECT_ENCRYPTION", 0, 1},

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -151,7 +151,7 @@ func RunTestTerraformBuiltInRules(t *testing.T, terraformVersion string) {
 		{"tf", "aws/ami/ebs_block_device_encrypted.tf", "AMI_VOLUMES_ENCRYPTED", 0, 2},
 		{"tf", "aws/ami_copy/encrypted.tf", "AMI_COPY_SNAPSHOTS_ENCRYPTED", 0, 2},
 		{"tf", "aws/instance/ebs_block_device_encrypted.tf", "EBS_BLOCK_DEVICE_ENCRYPTED", 0, 2},
-		{"both", "aws/ec2.tf", "EBS_VOLUME_ENCRYPTION", 0, 2},
+		{"tf", "aws/ebs_volume/encrypted.tf", "EBS_VOLUME_ENCRYPTION", 0, 2},
 		{"tf", "aws/cloudtrail/kms_key_id.tf", "CLOUDTRAIL_ENCRYPTION", 1, 0},
 		{"both", "aws/codebuild_project/project_encryption.tf", "CODEBUILD_PROJECT_ENCRYPTION", 0, 1},
 		{"both", "aws/codebuild_project/artifact_encryption.tf", "CODEBUILD_PROJECT_ARTIFACT_ENCRYPTION", 0, 3},

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -152,6 +152,7 @@ func RunTestTerraformBuiltInRules(t *testing.T, terraformVersion string) {
 		{"tf", "aws/ami_copy/encrypted.tf", "AMI_COPY_SNAPSHOTS_ENCRYPTED", 0, 2},
 		{"tf", "aws/instance/ebs_block_device_encrypted.tf", "EBS_BLOCK_DEVICE_ENCRYPTED", 0, 2},
 		{"tf", "aws/ebs_volume/encrypted.tf", "EBS_VOLUME_ENCRYPTION", 0, 2},
+		{"tf", "aws/subnet/map_public_ip_on_launch.tf", "EC2_SUBNET_MAP_PUBLIC", 1, 0},
 		{"tf", "aws/cloudtrail/kms_key_id.tf", "CLOUDTRAIL_ENCRYPTION", 1, 0},
 		{"both", "aws/codebuild_project/project_encryption.tf", "CODEBUILD_PROJECT_ENCRYPTION", 0, 1},
 		{"both", "aws/codebuild_project/artifact_encryption.tf", "CODEBUILD_PROJECT_ARTIFACT_ENCRYPTION", 0, 3},

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -161,7 +161,7 @@ func RunTestTerraformBuiltInRules(t *testing.T, terraformVersion string) {
 		{"tf", "aws/db_instance/storage_encryption.tf", "REPLICA_DB_INSTANCE_ENCRYPTION", 1, 0},
 		{"tf", "aws/db_instance/publicly_accessible.tf", "RDS_PUBLIC_AVAILABILITY", 0, 1},
 		{"tf", "aws/rds_cluster/storage_encryption.tf", "RDS_CLUSTER_ENCYPTION", 0, 5},
-		{"both", "aws/efs.tf", "EFS_ENCRYPTED", 0, 1},
+		{"tf", "aws/efs_file_system/encrypted.tf", "EFS_ENCRYPTED", 0, 2},
 		{"both", "aws/kinesis.tf", "KINESIS_FIREHOSE_DELIVERY_STREAM_ENCRYPTION", 0, 1},
 		{"tf", "aws/redshift/cluster/encrypted.tf", "REDSHIFT_CLUSTER_ENCRYPTION", 0, 2},
 		{"tf", "aws/redshift/cluster/enhanced_vpc_routing.tf", "REDSHIFT_CLUSTER_ENHANCED_VPC_ROUTING", 2, 0},

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -170,6 +170,7 @@ func RunTestTerraformBuiltInRules(t *testing.T, terraformVersion string) {
 		{"tf", "aws/redshift/cluster/publicly_accessible.tf", "REDSHIFT_CLUSTER_PUBLICLY_ACCESSIBLE", 0, 2},
 		{"tf", "aws/redshift/parameter_group/require_ssl.tf", "REDSHIFT_CLUSTER_PARAMETER_GROUP_REQUIRE_SSL", 2, 0},
 		{"tf", "aws/ecs_task_definition/secrets.tf", "ECS_ENVIRONMENT_SECRETS", 0, 3},
+		{"tf", "aws/emr_cluster/logging.tf", "AWS_EMR_CLUSTER_LOGGING", 1, 0},
 	}
 
 	// Run test cases

--- a/cli/builtin_terraform_test.go
+++ b/cli/builtin_terraform_test.go
@@ -171,6 +171,7 @@ func RunTestTerraformBuiltInRules(t *testing.T, terraformVersion string) {
 		{"tf", "aws/redshift/parameter_group/require_ssl.tf", "REDSHIFT_CLUSTER_PARAMETER_GROUP_REQUIRE_SSL", 2, 0},
 		{"tf", "aws/ecs_task_definition/secrets.tf", "ECS_ENVIRONMENT_SECRETS", 0, 3},
 		{"tf", "aws/emr_cluster/logging.tf", "AWS_EMR_CLUSTER_LOGGING", 1, 0},
+		{"tf", "aws/elasticache_replication_group/encryption_at_rest.tf", "ELASTICACHE_ENCRYPTION_REST", 0, 2},
 	}
 
 	// Run test cases

--- a/cli/testdata/builtin/terraform/aws/ebs_volume/encrypted.tf
+++ b/cli/testdata/builtin/terraform/aws/ebs_volume/encrypted.tf
@@ -1,0 +1,19 @@
+# Pass
+resource "aws_ebs_volume" "encrypted_set_to_true" {
+  availability_zone = "us-west-2a"
+  size              = 20
+  encrypted         = true
+}
+
+# Fail
+resource "aws_ebs_volume" "encrypted_set_to_false" {
+  availability_zone = "us-west-2a"
+  size              = 20
+  encrypted         = false
+}
+
+# Fail
+resource "aws_ebs_volume" "encrypted_not_set" {
+  availability_zone = "us-west-2a"
+  size              = 20
+}

--- a/cli/testdata/builtin/terraform/aws/ecs_task_definition/secrets.tf
+++ b/cli/testdata/builtin/terraform/aws/ecs_task_definition/secrets.tf
@@ -1,0 +1,249 @@
+# Pass
+resource "aws_ecs_task_definition" "container_definitions_environment_not_set" {
+  family                = "foo"
+  container_definitions = <<EOF
+[
+  {
+    "name": "bar",
+    "image": "foobar",
+    "cpu": 10,
+    "memory": 512,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ]
+  }
+]
+EOF
+}
+
+# Pass
+resource "aws_ecs_task_definition" "container_definitions_environment_aws_secrets_not_set" {
+  family                = "foo"
+  container_definitions = <<EOF
+[
+  {
+    "name": "bar",
+    "image": "foobar",
+    "cpu": 10,
+    "memory": 512,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ],
+    "environment": [
+        {
+            "name": "foo",
+            "value": "bar"
+        }
+    ]
+  }
+]
+EOF
+}
+
+# Pass
+resource "aws_ecs_task_definition" "container_definitions_environment_aws_secrets_not_set_20_character_capital_string" {
+  family                = "foo"
+  container_definitions = <<EOF
+[
+  {
+    "name": "bar",
+    "image": "foobar",
+    "cpu": 10,
+    "memory": 512,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ],
+    "environment": [
+        {
+            "name": "foo",
+            "value": "AXYZIOSFODNN7EXAMPLE"
+        }
+    ]
+  }
+]
+EOF
+}
+
+# Pass
+resource "aws_ecs_task_definition" "container_definitions_environment_aws_secrets_not_set_21_character_capital_string" {
+  family                = "foo"
+  container_definitions = <<EOF
+[
+  {
+    "name": "bar",
+    "image": "foobar",
+    "cpu": 10,
+    "memory": 512,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ],
+    "environment": [
+        {
+            "name": "foo",
+            "value": "AKIAIOSFODNN7FEXAMPLE"
+        }
+    ]
+  }
+]
+EOF
+}
+
+# Pass
+resource "aws_ecs_task_definition" "container_definitions_environment_aws_secrets_not_set_40_character_string" {
+  family                = "foo"
+  container_definitions = <<EOF
+[
+  {
+    "name": "bar",
+    "image": "foobar",
+    "cpu": 10,
+    "memory": 512,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ],
+    "environment": [
+        {
+            "name": "foo",
+            "value": "wJalrXUtnFEMI>K7MDENG^bPxRfiCYEXAMPLEKEY"
+        }
+    ]
+  }
+]
+EOF
+}
+
+# Pass
+resource "aws_ecs_task_definition" "container_definitions_environment_aws_secrets_not_set_41_character_string" {
+  family                = "foo"
+  container_definitions = <<EOF
+[
+  {
+    "name": "bar",
+    "image": "foobar",
+    "cpu": 10,
+    "memory": 512,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ],
+    "environment": [
+        {
+            "name": "foo",
+            "value": "wJalrXUtnFOOMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        }
+    ]
+  }
+]
+EOF
+}
+
+# Fail
+resource "aws_ecs_task_definition" "container_definitions_environment_aws_access_key_set" {
+  family                = "foo"
+  container_definitions = <<EOF
+[
+  {
+    "name": "bar",
+    "image": "foobar",
+    "cpu": 10,
+    "memory": 512,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ],
+    "environment": [
+        {
+            "name": "foo",
+            "value": "AKIAIOSFODNN7EXAMPLE"
+        }
+    ]
+  }
+]
+EOF
+}
+
+# Fail
+resource "aws_ecs_task_definition" "container_definitions_environment_aws_secret_access_key_set" {
+  family                = "foo"
+  container_definitions = <<EOF
+[
+  {
+    "name": "bar",
+    "image": "foobar",
+    "cpu": 10,
+    "memory": 512,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ],
+    "environment": [
+        {
+            "name": "foo",
+            "value": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        }
+    ]
+  }
+]
+EOF
+}
+
+# Fail
+resource "aws_ecs_task_definition" "container_definitions_environment_aws_access_key_and_secret_access_key_set" {
+  family                = "foo"
+  container_definitions = <<EOF
+[
+  {
+    "name": "bar",
+    "image": "foobar",
+    "cpu": 10,
+    "memory": 512,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ],
+    "environment": [
+        {
+            "name": "foo",
+            "value": "AIPAIOSFODNN7EXAMPLE"
+        },
+        {
+            "name": "bar",
+            "value": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+        }
+    ]
+  }
+]
+EOF
+}

--- a/cli/testdata/builtin/terraform/aws/efs_file_system/encrypted.tf
+++ b/cli/testdata/builtin/terraform/aws/efs_file_system/encrypted.tf
@@ -1,0 +1,16 @@
+# Pass
+resource "aws_efs_file_system" "encrypted_set_to_true" {
+  creation_token = "foo"
+  encrypted      = true
+}
+
+# Fail
+resource "aws_efs_file_system" "encrypted_set_to_false" {
+  creation_token = "foo"
+  encrypted      = false
+}
+
+# Fail
+resource "aws_efs_file_system" "encrypted_not_set" {
+  creation_token = "foo"
+}

--- a/cli/testdata/builtin/terraform/aws/elasticache_replication_group/encryption_at_rest.tf
+++ b/cli/testdata/builtin/terraform/aws/elasticache_replication_group/encryption_at_rest.tf
@@ -1,0 +1,25 @@
+# Pass
+resource "aws_elasticache_replication_group" "at_rest_encryption_enabled_is_set_to_true" {
+  replication_group_id          = "foo"
+  replication_group_description = "test description"
+  node_type                     = "cache.m4.large"
+  number_cache_clusters         = 2
+  at_rest_encryption_enabled    = true
+}
+
+# Fail
+resource "aws_elasticache_replication_group" "at_rest_encryption_enabled_is_set_to_false" {
+  replication_group_id          = "foo"
+  replication_group_description = "test description"
+  node_type                     = "cache.m4.large"
+  number_cache_clusters         = 2
+  at_rest_encryption_enabled    = false
+}
+
+# Fail
+resource "aws_elasticache_replication_group" "at_rest_encryption_enabled_is_not_set" {
+  replication_group_id          = "foo"
+  replication_group_description = "test description"
+  node_type                     = "cache.m4.large"
+  number_cache_clusters         = 2
+}

--- a/cli/testdata/builtin/terraform/aws/elasticache_replication_group/encryption_in_transit.tf
+++ b/cli/testdata/builtin/terraform/aws/elasticache_replication_group/encryption_in_transit.tf
@@ -1,0 +1,25 @@
+# Pass
+resource "aws_elasticache_replication_group" "transit_encryption_enabled_is_set_to_true" {
+  replication_group_id          = "foo"
+  replication_group_description = "test description"
+  node_type                     = "cache.m4.large"
+  number_cache_clusters         = 2
+  transit_encryption_enabled    = true
+}
+
+# Fail
+resource "aws_elasticache_replication_group" "transit_encryption_enabled_is_set_to_false" {
+  replication_group_id          = "foo"
+  replication_group_description = "test description"
+  node_type                     = "cache.m4.large"
+  number_cache_clusters         = 2
+  transit_encryption_enabled    = false
+}
+
+# Fail
+resource "aws_elasticache_replication_group" "transit_encryption_enabled_is_not_set" {
+  replication_group_id          = "foo"
+  replication_group_description = "test description"
+  node_type                     = "cache.m4.large"
+  number_cache_clusters         = 2
+}

--- a/cli/testdata/builtin/terraform/aws/emr_cluster/logging.tf
+++ b/cli/testdata/builtin/terraform/aws/emr_cluster/logging.tf
@@ -1,0 +1,18 @@
+## Setup Helper
+resource "aws_s3_bucket" "test_bucket" {
+}
+
+# Pass
+resource "aws_emr_cluster" "log_uri_is_set" {
+  name          = "foo"
+  release_label = "emr-4.6.0"
+  service_role  = "arn:aws:iam::1234567890:role/EMR_DefaultRole"
+  log_uri       = "s3://${aws_s3_bucket.test_bucket.bucket}/"
+}
+
+# Fail
+resource "aws_emr_cluster" "log_uri_is_set" {
+  name          = "foo"
+  release_label = "emr-4.6.0"
+  service_role  = "arn:aws:iam::1234567890:role/EMR_DefaultRole"
+}

--- a/cli/testdata/builtin/terraform/aws/instance/ebs_block_device_encrypted.tf
+++ b/cli/testdata/builtin/terraform/aws/instance/ebs_block_device_encrypted.tf
@@ -1,0 +1,57 @@
+## Setup Helper
+data "aws_ami" "test_ami" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+# Pass
+resource "aws_instance" "ebs_block_device_not_set" {
+  ami           = "${data.aws_ami.ubuntu.id}"
+  instance_type = "t2.micro"
+}
+
+# Pass
+resource "aws_instance" "ebs_block_device_encrypted_set_to_true" {
+  ami           = "${data.aws_ami.ubuntu.id}"
+  instance_type = "t2.micro"
+
+  ebs_block_device {
+    device_name = "/dev/xvda"
+    volume_size = 20
+    encrypted   = true
+  }
+}
+
+# Fail
+resource "aws_instance" "ebs_block_device_encrypted_set_to_false" {
+  ami           = "${data.aws_ami.ubuntu.id}"
+  instance_type = "t2.micro"
+
+  ebs_block_device {
+    device_name = "/dev/xvda"
+    volume_size = 20
+    encrypted   = false
+  }
+}
+
+# Fail
+resource "aws_instance" "ebs_block_device_encrypted_not_set" {
+  ami           = "${data.aws_ami.ubuntu.id}"
+  instance_type = "t2.micro"
+
+  ebs_block_device {
+    device_name = "/dev/xvda"
+    volume_size = 20
+  }
+}

--- a/cli/testdata/builtin/terraform/aws/subnet/map_public_ip_on_launch.tf
+++ b/cli/testdata/builtin/terraform/aws/subnet/map_public_ip_on_launch.tf
@@ -1,0 +1,24 @@
+## Setup Helper
+resource "aws_vpc" "test_vpc" {
+  cidr_block = "10.0.0.0/16"
+}
+
+# Pass
+resource "aws_subnet" "map_public_ip_on_launch_not_set" {
+  vpc_id     = "${aws_vpc.test_vpc.id}"
+  cidr_block = "172.2.0.0/24"
+}
+
+# Pass
+resource "aws_subnet" "map_public_ip_on_launch_set_to_false" {
+  vpc_id                  = "${aws_vpc.test_vpc.id}"
+  cidr_block              = "172.2.0.0/24"
+  map_public_ip_on_launch = false
+}
+
+# Warn
+resource "aws_subnet" "map_public_ip_on_launch_set_to_true" {
+  vpc_id                  = "${aws_vpc.test_vpc.id}"
+  cidr_block              = "172.2.0.0/24"
+  map_public_ip_on_launch = true
+}

--- a/go.mod
+++ b/go.mod
@@ -25,5 +25,5 @@ require (
 	golang.org/x/crypto v0.0.0-20200214034016-1d94cc7ab1c6 // indirect
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/sys v0.0.0-20200217220822-9197077df867 // indirect
-	golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd // indirect
+	golang.org/x/tools v0.0.0-20200224181240-023911ca70b2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -506,6 +506,8 @@ golang.org/x/tools v0.0.0-20200221191710-57f3fb51f507 h1:zE128a8BUJqwFqwi8LxUnOd
 golang.org/x/tools v0.0.0-20200221191710-57f3fb51f507/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd h1:hHkvGJK23seRCflePJnVa9IMv8fsuavSCWKd11kDQFs=
 golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200224181240-023911ca70b2 h1:L/G4KZvrQn7FWLN/LlulBtBzrLUhqjiGfTWWDmrh+IQ=
+golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=


### PR DESCRIPTION
Partial for #123 

This covers the EC2, EFS, ECS, EMR, & Elasticache rules for Terraform11.

* Removed `kms_key_id` check from being a FAILURE in the following rules:
  * `EBS_VOLUME_ENCRYPTION`
  * `EFS_ENCRYPTED`
* Updated regex match for `ECS_ENVIRONMENT_SECRETS` rule to find either an Access_Key or Secret_Access_Key as a value. These no longer need to be listed together or with a key name of `KEY` or `SECRET` to match and fail.
* Added several rules to the test suite as they were missing