### PR TITLE
resolves issue #146. moved minimal, relevant code from feature branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,5 +25,5 @@ require (
 	golang.org/x/crypto v0.0.0-20200214034016-1d94cc7ab1c6 // indirect
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/sys v0.0.0-20200217220822-9197077df867 // indirect
-	golang.org/x/tools v0.0.0-20200225022059-a0ec867d517c // indirect
+	golang.org/x/tools v0.0.0-20200227193342-b3f10971cb29 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -510,6 +510,8 @@ golang.org/x/tools v0.0.0-20200224181240-023911ca70b2 h1:L/G4KZvrQn7FWLN/LlulBtB
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200225022059-a0ec867d517c h1:cmkqWf0jTLsPn3dn28dkzCF+MoDvuZS7pTwHwGmkqiU=
 golang.org/x/tools v0.0.0-20200225022059-a0ec867d517c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200227193342-b3f10971cb29 h1:gZO+3X1BaUgKEk78zRnb5VySro9NQVkdA1UakZx/Ojg=
+golang.org/x/tools v0.0.0-20200227193342-b3f10971cb29/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/linter/terraform_v12.go
+++ b/linter/terraform_v12.go
@@ -1,233 +1,234 @@
 package linter
 
 import (
-    "github.com/hashicorp/hcl/v2"
-    "github.com/stelligent/config-lint/assertion"
-    "github.com/stelligent/config-lint/linter/tf12parser"
-    "github.com/zclconf/go-cty/cty"
-    "strconv"
-    "strings"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stelligent/config-lint/assertion"
+	"github.com/stelligent/config-lint/linter/tf12parser"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type (
-    // Terraform12ResourceLoader converts Terraform configuration files into JSON objects
-    Terraform12ResourceLoader struct{}
+	// Terraform12ResourceLoader converts Terraform configuration files into JSON objects
+	Terraform12ResourceLoader struct{}
 
-    // Terraform12LoadResult collects all the returns value for parsing an HCL string
-    Terraform12LoadResult struct {
-        Resources []assertion.Resource
-        Data      []interface{}
-        Providers []interface{}
-        Modules   []interface{}
-        Variables []Variable
-        AST       *hcl.File
-    }
+	// Terraform12LoadResult collects all the returns value for parsing an HCL string
+	Terraform12LoadResult struct {
+		Resources []assertion.Resource
+		Data      []interface{}
+		Providers []interface{}
+		Modules   []interface{}
+		Variables []Variable
+		AST       *hcl.File
+	}
 )
 
 // Load parses an HCLv2 file into a collection or Resource objects
 //TODO: This should be unused, but can't remove due to the interface, I think?
 func (l Terraform12ResourceLoader) Load(filename string) (FileResources, error) {
-    loaded := FileResources{
-        Resources: []assertion.Resource{},
-    }
-    result, err := loadHCLv2([]string{filename})
-    if err != nil {
-        return loaded, err
-    }
-    loaded.Resources = result.Resources
+	loaded := FileResources{
+		Resources: []assertion.Resource{},
+	}
+	result, err := loadHCLv2([]string{filename})
+	if err != nil {
+		return loaded, err
+	}
+	loaded.Resources = result.Resources
 
-    assertion.DebugJSON("loaded.Resources", loaded.Resources)
-    return loaded, nil
+	assertion.DebugJSON("loaded.Resources", loaded.Resources)
+	return loaded, nil
 }
 
 func (l Terraform12ResourceLoader) LoadMany(filenames []string) (FileResources, error) {
-    loaded := FileResources{
-        Resources: []assertion.Resource{},
-    }
-    result, err := loadHCLv2(filenames)
-    if err != nil {
-        return loaded, err
-    }
-    loaded.Resources = result.Resources
+	loaded := FileResources{
+		Resources: []assertion.Resource{},
+	}
+	result, err := loadHCLv2(filenames)
+	if err != nil {
+		return loaded, err
+	}
+	loaded.Resources = result.Resources
 
-    assertion.DebugJSON("loaded.Resources", loaded.Resources)
-    return loaded, nil
+	assertion.DebugJSON("loaded.Resources", loaded.Resources)
+	return loaded, nil
 }
 
 func loadHCLv2(paths []string) (Terraform12LoadResult, error) {
-    result := Terraform12LoadResult{
-        Resources: []assertion.Resource{},
-        Data:      []interface{}{},
-        Providers: []interface{}{},
-        Modules:   []interface{}{},
-        Variables: []Variable{},
-    }
+	result := Terraform12LoadResult{
+		Resources: []assertion.Resource{},
+		Data:      []interface{}{},
+		Providers: []interface{}{},
+		Modules:   []interface{}{},
+		Variables: []Variable{},
+	}
 
-    parser := *tf12parser.New()
-    blocks, err := parser.ParseMany(paths)
-    if err != nil {
-        return result, err
-    }
+	parser := *tf12parser.New()
+	blocks, err := parser.ParseMany(paths)
+	if err != nil {
+		return result, err
+	}
 
-    // Get all Terraform blocks of a given type and append to the slice of Resources
-    blockTypes := []string{"resource", "provider", "data", "module"}
-    for _, blockType := range blockTypes {
-        result.Resources = append(result.Resources, getBlocksOfType(blocks, blockType)...)
-    }
+	// Get all Terraform blocks of a given type and append to the slice of Resources
+	blockTypes := []string{"resource", "provider", "data", "module"}
+	for _, blockType := range blockTypes {
+		result.Resources = append(result.Resources, getBlocksOfType(blocks, blockType)...)
+	}
 
-    for _, resource := range result.Resources {
-        properties, err := parseJSONDocuments(resource.Properties)
-        if err != nil {
-            return result, err
-        }
-        resource.Properties = properties
-    }
+	for _, resource := range result.Resources {
+		properties, err := parseJSONDocuments(resource.Properties)
+		if err != nil {
+			return result, err
+		}
+		resource.Properties = properties
+	}
 
-    assertion.Debugf("LoadHCL Variables: %v\n", result.Variables)
-    return result, nil
+	assertion.Debugf("LoadHCL Variables: %v\n", result.Variables)
+	return result, nil
 }
 
 // Retrieves Terraform blocks of a specific type
 // and places them in a slice of assertion.Resources.
 func getBlocksOfType(blocks tf12parser.Blocks, blockType string) []assertion.Resource {
-    var id string
-    var resources []assertion.Resource
+	var id string
+	var resources []assertion.Resource
 
-    tfBlocks := blocks.OfType(blockType)
-    i := 0
+	tfBlocks := blocks.OfType(blockType)
+	i := 0
 
-    // If there is no Terraform ID for a block (in the case of Providers and Modules),
-    // set the id variable to an auto-incrementing integer.
-    // Otherwise, set it to the second item in the block's Labels.
-    for _, block := range tfBlocks {
-        if len(block.Labels()) > 1 {
-            id = block.Labels()[1]
-        } else {
-            id = strconv.Itoa(i)
-            i++
-        }
-        if block.Type() != "module" {
-            resource := assertion.Resource{
-                ID:         id,
-                Type:       block.Labels()[0],
-                Category:   blockType,
-                Properties: attributesToMap(*block),
-                Filename:   block.Range().Filename,
-                LineNumber: block.Range().StartLine,
-            }
-            resources = append(resources, resource)
-        } else {
-            moduleSource := block.GetAttribute("source")
-            resource := assertion.Resource{
-                ID:         block.Labels()[0],
-                Type:       moduleSource.Value().AsString(),
-                Category:   blockType,
-                Properties: attributesToMap(*block),
-                Filename:   block.Range().Filename,
-                LineNumber: block.Range().StartLine,
-            }
-            resources = append(resources, resource)
-        }
-    }
-    return resources
+	// If there is no Terraform ID for a block (in the case of Providers and Modules),
+	// set the id variable to an auto-incrementing integer.
+	// Otherwise, set it to the second item in the block's Labels.
+	for _, block := range tfBlocks {
+		if len(block.Labels()) > 1 {
+			id = block.Labels()[1]
+		} else {
+			id = strconv.Itoa(i)
+			i++
+		}
+		if block.Type() != "module" {
+			resource := assertion.Resource{
+				ID:         id,
+				Type:       block.Labels()[0],
+				Category:   blockType,
+				Properties: attributesToMap(*block),
+				Filename:   block.Range().Filename,
+				LineNumber: block.Range().StartLine,
+			}
+			resources = append(resources, resource)
+		} else {
+			moduleSource := block.GetAttribute("source")
+			resource := assertion.Resource{
+				ID:         block.Labels()[0],
+				Type:       moduleSource.Value().AsString(),
+				Category:   blockType,
+				Properties: attributesToMap(*block),
+				Filename:   block.Range().Filename,
+				LineNumber: block.Range().StartLine,
+			}
+			resources = append(resources, resource)
+		}
+	}
+	return resources
 }
 
 func attributesToMap(block tf12parser.Block) map[string]interface{} {
-    propertyMap := make(map[string]interface{})
-    allBlocks := block.AllBlocks()
-    for _, currentBlock := range allBlocks {
-        var toAppend []interface{}
-        toAppend = append(toAppend, attributesToMap(*currentBlock))
-        if propertyMap[currentBlock.Type()] == nil {
-            propertyMap[currentBlock.Type()] = toAppend
-        } else {
-            v := propertyMap[currentBlock.Type()].([]interface{})
-            v = append(v, toAppend[0])
-            propertyMap[currentBlock.Type()] = v
-        }
-    }
-    attributes := block.GetAttributes()
-    for _, attribute := range attributes {
-        value := attribute.Value()
-        if value.Type().IsTupleType() {
-            innerArray := make([]interface{}, 0)
+	propertyMap := make(map[string]interface{})
+	allBlocks := block.AllBlocks()
+	for _, currentBlock := range allBlocks {
+		var toAppend []interface{}
+		toAppend = append(toAppend, attributesToMap(*currentBlock))
+		if propertyMap[currentBlock.Type()] == nil {
+			propertyMap[currentBlock.Type()] = toAppend
+		} else {
+			v := propertyMap[currentBlock.Type()].([]interface{})
+			v = append(v, toAppend[0])
+			propertyMap[currentBlock.Type()] = v
+		}
+	}
+	attributes := block.GetAttributes()
+	for _, attribute := range attributes {
+		value := attribute.Value()
+		if value.Type().IsTupleType() {
+			innerArray := make([]interface{}, 0)
 
-            iter := value.ElementIterator()
-            for iter.Next() {
-                _, iterValue := iter.Element()
-                if iterValue.CanIterateElements() {
-                    iterateElements(propertyMap, attribute.Name(), iterValue)
-                } else {
-                    innerArray = append(innerArray, ctyValueToString(iterValue))
-                }
-            }
-            propertyMap[attribute.Name()] = innerArray
-        } else if value.CanIterateElements() {
-            iterateElements(propertyMap, attribute.Name(), value)
-        } else {
-            setValue(propertyMap, attribute.Name(), ctyValueToString(value))
-        }
-    }
-    return propertyMap
+			iter := value.ElementIterator()
+			for iter.Next() {
+				_, iterValue := iter.Element()
+				if iterValue.CanIterateElements() {
+					iterateElements(propertyMap, attribute.Name(), iterValue)
+				} else {
+					innerArray = append(innerArray, ctyValueToString(iterValue))
+				}
+			}
+			propertyMap[attribute.Name()] = innerArray
+		} else if value.CanIterateElements() {
+			iterateElements(propertyMap, attribute.Name(), value)
+		} else {
+			setValue(propertyMap, attribute.Name(), ctyValueToString(value))
+		}
+	}
+	return propertyMap
 }
 
 func iterateElements(propertyMap map[string]interface{}, name string, value cty.Value) {
-    var innerArray []interface{}
-    innerMap := make(map[string]interface{})
-    innerArray = append(innerArray, innerMap)
-    propertyMap[name] = innerArray
+	var innerArray []interface{}
+	innerMap := make(map[string]interface{})
+	innerArray = append(innerArray, innerMap)
+	propertyMap[name] = innerArray
 
-    iter := value.ElementIterator()
-    for iter.Next() {
-        key, value := iter.Element()
-        if value.CanIterateElements() {
-            iterateElements(innerMap, ctyValueToString(key), value)
-        } else {
-            setValue(innerMap, ctyValueToString(key), ctyValueToString(value))
-        }
-    }
+	iter := value.ElementIterator()
+	for iter.Next() {
+		key, value := iter.Element()
+		if value.CanIterateElements() {
+			iterateElements(innerMap, ctyValueToString(key), value)
+		} else {
+			setValue(innerMap, ctyValueToString(key), ctyValueToString(value))
+		}
+	}
 }
 
 func setValue(m map[string]interface{}, name string, value string) {
-    environmentVariable := getVariableFromEnvironment(name)
-    if environmentVariable == "" {
-        m[name] = value
-    } else {
-        m[name] = environmentVariable
-    }
+	environmentVariable := getVariableFromEnvironment(name)
+	if environmentVariable == "" {
+		m[name] = value
+	} else {
+		m[name] = environmentVariable
+	}
 }
 
 func ctyValueToString(value cty.Value) string {
-    // In case the value is nil but the type is not necessarily <nil>, ~~return an empty string~~
-    // Update: return an actual string.
-    // We cannot evaluate tf generated values in tf12, such as referenced arn, but we still want to be able to check for it
-    if value.IsNull() || !value.IsKnown() {
-        return "UNDEFINED"
-    } else {
-        switch value.Type() {
-        case cty.NilType:
-            return ""
-        case cty.Bool:
-            if value.True() {
-                return "true"
-            } else {
-                return "false"
-            }
-        case cty.String:
-            return strings.Trim(value.AsString(), "\n")
-        case cty.Number:
-            if value.RawEquals(cty.PositiveInfinity) || value.RawEquals(cty.NegativeInfinity) {
-                panic("cannot convert infinity to string")
-            }
-            return value.AsBigFloat().Text('f', -1)
-        default:
-            panic("unsupported primitive type")
-            //return ""
-        }
-    }
+	// In case the value is nil but the type is not necessarily <nil>, ~~return an empty string~~
+	// Update: return an actual string.
+	// We cannot evaluate tf generated values in tf12, such as referenced arn, but we still want to be able to check for it
+	if value.IsNull() || !value.IsKnown() {
+		return "UNDEFINED"
+	} else {
+		switch value.Type() {
+		case cty.NilType:
+			return ""
+		case cty.Bool:
+			if value.True() {
+				return "true"
+			} else {
+				return "false"
+			}
+		case cty.String:
+			return strings.Trim(value.AsString(), "\n")
+		case cty.Number:
+			if value.RawEquals(cty.PositiveInfinity) || value.RawEquals(cty.NegativeInfinity) {
+				panic("cannot convert infinity to string")
+			}
+			return value.AsBigFloat().Text('f', -1)
+		default:
+			panic("unsupported primitive type")
+			//return ""
+		}
+	}
 }
 
 // PostLoad resolves variable expressions
 func (l Terraform12ResourceLoader) PostLoad(inputResources FileResources) ([]assertion.Resource, error) {
-    return inputResources.Resources, nil
+	return inputResources.Resources, nil
 }

--- a/linter/terraform_v12.go
+++ b/linter/terraform_v12.go
@@ -1,231 +1,233 @@
 package linter
 
 import (
-	"github.com/hashicorp/hcl/v2"
-	"github.com/stelligent/config-lint/assertion"
-	"github.com/stelligent/config-lint/linter/tf12parser"
-	"github.com/zclconf/go-cty/cty"
-	"strconv"
-	"strings"
+    "github.com/hashicorp/hcl/v2"
+    "github.com/stelligent/config-lint/assertion"
+    "github.com/stelligent/config-lint/linter/tf12parser"
+    "github.com/zclconf/go-cty/cty"
+    "strconv"
+    "strings"
 )
 
 type (
-	// Terraform12ResourceLoader converts Terraform configuration files into JSON objects
-	Terraform12ResourceLoader struct{}
+    // Terraform12ResourceLoader converts Terraform configuration files into JSON objects
+    Terraform12ResourceLoader struct{}
 
-	// Terraform12LoadResult collects all the returns value for parsing an HCL string
-	Terraform12LoadResult struct {
-		Resources []assertion.Resource
-		Data      []interface{}
-		Providers []interface{}
-		Modules   []interface{}
-		Variables []Variable
-		AST       *hcl.File
-	}
+    // Terraform12LoadResult collects all the returns value for parsing an HCL string
+    Terraform12LoadResult struct {
+        Resources []assertion.Resource
+        Data      []interface{}
+        Providers []interface{}
+        Modules   []interface{}
+        Variables []Variable
+        AST       *hcl.File
+    }
 )
 
 // Load parses an HCLv2 file into a collection or Resource objects
 //TODO: This should be unused, but can't remove due to the interface, I think?
 func (l Terraform12ResourceLoader) Load(filename string) (FileResources, error) {
-	loaded := FileResources{
-		Resources: []assertion.Resource{},
-	}
-	result, err := loadHCLv2([]string{filename})
-	if err != nil {
-		return loaded, err
-	}
-	loaded.Resources = result.Resources
+    loaded := FileResources{
+        Resources: []assertion.Resource{},
+    }
+    result, err := loadHCLv2([]string{filename})
+    if err != nil {
+        return loaded, err
+    }
+    loaded.Resources = result.Resources
 
-	assertion.DebugJSON("loaded.Resources", loaded.Resources)
-	return loaded, nil
+    assertion.DebugJSON("loaded.Resources", loaded.Resources)
+    return loaded, nil
 }
 
 func (l Terraform12ResourceLoader) LoadMany(filenames []string) (FileResources, error) {
-	loaded := FileResources{
-		Resources: []assertion.Resource{},
-	}
-	result, err := loadHCLv2(filenames)
-	if err != nil {
-		return loaded, err
-	}
-	loaded.Resources = result.Resources
+    loaded := FileResources{
+        Resources: []assertion.Resource{},
+    }
+    result, err := loadHCLv2(filenames)
+    if err != nil {
+        return loaded, err
+    }
+    loaded.Resources = result.Resources
 
-	assertion.DebugJSON("loaded.Resources", loaded.Resources)
-	return loaded, nil
+    assertion.DebugJSON("loaded.Resources", loaded.Resources)
+    return loaded, nil
 }
 
 func loadHCLv2(paths []string) (Terraform12LoadResult, error) {
-	result := Terraform12LoadResult{
-		Resources: []assertion.Resource{},
-		Data:      []interface{}{},
-		Providers: []interface{}{},
-		Modules:   []interface{}{},
-		Variables: []Variable{},
-	}
+    result := Terraform12LoadResult{
+        Resources: []assertion.Resource{},
+        Data:      []interface{}{},
+        Providers: []interface{}{},
+        Modules:   []interface{}{},
+        Variables: []Variable{},
+    }
 
-	parser := *tf12parser.New()
-	blocks, err := parser.ParseMany(paths)
-	if err != nil {
-		return result, err
-	}
+    parser := *tf12parser.New()
+    blocks, err := parser.ParseMany(paths)
+    if err != nil {
+        return result, err
+    }
 
-	// Get all Terraform blocks of a given type and append to the slice of Resources
-	blockTypes := []string{"resource", "provider", "data", "module"}
-	for _, blockType := range blockTypes {
-		result.Resources = append(result.Resources, getBlocksOfType(blocks, blockType)...)
-	}
+    // Get all Terraform blocks of a given type and append to the slice of Resources
+    blockTypes := []string{"resource", "provider", "data", "module"}
+    for _, blockType := range blockTypes {
+        result.Resources = append(result.Resources, getBlocksOfType(blocks, blockType)...)
+    }
 
-	for _, resource := range result.Resources {
-		properties, err := parseJSONDocuments(resource.Properties)
-		if err != nil {
-			return result, err
-		}
-		resource.Properties = properties
-	}
+    for _, resource := range result.Resources {
+        properties, err := parseJSONDocuments(resource.Properties)
+        if err != nil {
+            return result, err
+        }
+        resource.Properties = properties
+    }
 
-	assertion.Debugf("LoadHCL Variables: %v\n", result.Variables)
-	return result, nil
+    assertion.Debugf("LoadHCL Variables: %v\n", result.Variables)
+    return result, nil
 }
 
 // Retrieves Terraform blocks of a specific type
 // and places them in a slice of assertion.Resources.
 func getBlocksOfType(blocks tf12parser.Blocks, blockType string) []assertion.Resource {
-	var id string
-	var resources []assertion.Resource
+    var id string
+    var resources []assertion.Resource
 
-	tfBlocks := blocks.OfType(blockType)
-	i := 0
+    tfBlocks := blocks.OfType(blockType)
+    i := 0
 
-	// If there is no Terraform ID for a block (in the case of Providers and Modules),
-	// set the id variable to an auto-incrementing integer.
-	// Otherwise, set it to the second item in the block's Labels.
-	for _, block := range tfBlocks {
-		if len(block.Labels()) > 1 {
-			id = block.Labels()[1]
-		} else {
-			id = strconv.Itoa(i)
-			i++
-		}
-		if block.Type() != "module" {
-			resource := assertion.Resource{
-				ID:         id,
-				Type:       block.Labels()[0],
-				Category:   blockType,
-				Properties: attributesToMap(*block),
-				Filename:   block.Range().Filename,
-				LineNumber: block.Range().StartLine,
-			}
-			resources = append(resources, resource)
-		} else {
-			moduleSource := block.GetAttribute("source")
-			resource := assertion.Resource{
-				ID:         block.Labels()[0],
-				Type:       moduleSource.Value().AsString(),
-				Category:   blockType,
-				Properties: attributesToMap(*block),
-				Filename:   block.Range().Filename,
-				LineNumber: block.Range().StartLine,
-			}
-			resources = append(resources, resource)
-		}
-	}
-	return resources
+    // If there is no Terraform ID for a block (in the case of Providers and Modules),
+    // set the id variable to an auto-incrementing integer.
+    // Otherwise, set it to the second item in the block's Labels.
+    for _, block := range tfBlocks {
+        if len(block.Labels()) > 1 {
+            id = block.Labels()[1]
+        } else {
+            id = strconv.Itoa(i)
+            i++
+        }
+        if block.Type() != "module" {
+            resource := assertion.Resource{
+                ID:         id,
+                Type:       block.Labels()[0],
+                Category:   blockType,
+                Properties: attributesToMap(*block),
+                Filename:   block.Range().Filename,
+                LineNumber: block.Range().StartLine,
+            }
+            resources = append(resources, resource)
+        } else {
+            moduleSource := block.GetAttribute("source")
+            resource := assertion.Resource{
+                ID:         block.Labels()[0],
+                Type:       moduleSource.Value().AsString(),
+                Category:   blockType,
+                Properties: attributesToMap(*block),
+                Filename:   block.Range().Filename,
+                LineNumber: block.Range().StartLine,
+            }
+            resources = append(resources, resource)
+        }
+    }
+    return resources
 }
 
 func attributesToMap(block tf12parser.Block) map[string]interface{} {
-	propertyMap := make(map[string]interface{})
-	allBlocks := block.AllBlocks()
-	for _, currentBlock := range allBlocks {
-		var toAppend []interface{}
-		toAppend = append(toAppend, attributesToMap(*currentBlock))
-		if propertyMap[currentBlock.Type()] == nil {
-			propertyMap[currentBlock.Type()] = toAppend
-		} else {
-			v := propertyMap[currentBlock.Type()].([]interface{})
-			v = append(v, toAppend[0])
-			propertyMap[currentBlock.Type()] = v
-		}
-	}
-	attributes := block.GetAttributes()
-	for _, attribute := range attributes {
-		value := attribute.Value()
-		if value.Type().IsTupleType() {
-			innerArray := make([]interface{}, 0)
+    propertyMap := make(map[string]interface{})
+    allBlocks := block.AllBlocks()
+    for _, currentBlock := range allBlocks {
+        var toAppend []interface{}
+        toAppend = append(toAppend, attributesToMap(*currentBlock))
+        if propertyMap[currentBlock.Type()] == nil {
+            propertyMap[currentBlock.Type()] = toAppend
+        } else {
+            v := propertyMap[currentBlock.Type()].([]interface{})
+            v = append(v, toAppend[0])
+            propertyMap[currentBlock.Type()] = v
+        }
+    }
+    attributes := block.GetAttributes()
+    for _, attribute := range attributes {
+        value := attribute.Value()
+        if value.Type().IsTupleType() {
+            innerArray := make([]interface{}, 0)
 
-			iter := value.ElementIterator()
-			for iter.Next() {
-				_, iterValue := iter.Element()
-				if iterValue.CanIterateElements() {
-					iterateElements(propertyMap, attribute.Name(), iterValue)
-				} else {
-					innerArray = append(innerArray, ctyValueToString(iterValue))
-				}
-			}
-			propertyMap[attribute.Name()] = innerArray
-		} else if value.CanIterateElements() {
-			iterateElements(propertyMap, attribute.Name(), value)
-		} else {
-			setValue(propertyMap, attribute.Name(), ctyValueToString(value))
-		}
-	}
-	return propertyMap
+            iter := value.ElementIterator()
+            for iter.Next() {
+                _, iterValue := iter.Element()
+                if iterValue.CanIterateElements() {
+                    iterateElements(propertyMap, attribute.Name(), iterValue)
+                } else {
+                    innerArray = append(innerArray, ctyValueToString(iterValue))
+                }
+            }
+            propertyMap[attribute.Name()] = innerArray
+        } else if value.CanIterateElements() {
+            iterateElements(propertyMap, attribute.Name(), value)
+        } else {
+            setValue(propertyMap, attribute.Name(), ctyValueToString(value))
+        }
+    }
+    return propertyMap
 }
 
 func iterateElements(propertyMap map[string]interface{}, name string, value cty.Value) {
-	var innerArray []interface{}
-	innerMap := make(map[string]interface{})
-	innerArray = append(innerArray, innerMap)
-	propertyMap[name] = innerArray
+    var innerArray []interface{}
+    innerMap := make(map[string]interface{})
+    innerArray = append(innerArray, innerMap)
+    propertyMap[name] = innerArray
 
-	iter := value.ElementIterator()
-	for iter.Next() {
-		key, value := iter.Element()
-		if value.CanIterateElements() {
-			iterateElements(innerMap, ctyValueToString(key), value)
-		} else {
-			setValue(innerMap, ctyValueToString(key), ctyValueToString(value))
-		}
-	}
+    iter := value.ElementIterator()
+    for iter.Next() {
+        key, value := iter.Element()
+        if value.CanIterateElements() {
+            iterateElements(innerMap, ctyValueToString(key), value)
+        } else {
+            setValue(innerMap, ctyValueToString(key), ctyValueToString(value))
+        }
+    }
 }
 
 func setValue(m map[string]interface{}, name string, value string) {
-	environmentVariable := getVariableFromEnvironment(name)
-	if environmentVariable == "" {
-		m[name] = value
-	} else {
-		m[name] = environmentVariable
-	}
+    environmentVariable := getVariableFromEnvironment(name)
+    if environmentVariable == "" {
+        m[name] = value
+    } else {
+        m[name] = environmentVariable
+    }
 }
 
 func ctyValueToString(value cty.Value) string {
-	// In case the value is nil but the type is not necessarily <nil>, return an empty string
-	if value.IsNull() || !value.IsKnown() {
-		return ""
-	} else {
-		switch value.Type() {
-		case cty.NilType:
-			return ""
-		case cty.Bool:
-			if value.True() {
-				return "true"
-			} else {
-				return "false"
-			}
-		case cty.String:
-			return strings.Trim(value.AsString(), "\n")
-		case cty.Number:
-			if value.RawEquals(cty.PositiveInfinity) || value.RawEquals(cty.NegativeInfinity) {
-				panic("cannot convert infinity to string")
-			}
-			return value.AsBigFloat().Text('f', -1)
-		default:
-			panic("unsupported primitive type")
-			//return ""
-		}
-	}
+    // In case the value is nil but the type is not necessarily <nil>, ~~return an empty string~~
+    // Update: return an actual string.
+    // We cannot evaluate tf generated values in tf12, such as referenced arn, but we still want to be able to check for it
+    if value.IsNull() || !value.IsKnown() {
+        return "UNDEFINED"
+    } else {
+        switch value.Type() {
+        case cty.NilType:
+            return ""
+        case cty.Bool:
+            if value.True() {
+                return "true"
+            } else {
+                return "false"
+            }
+        case cty.String:
+            return strings.Trim(value.AsString(), "\n")
+        case cty.Number:
+            if value.RawEquals(cty.PositiveInfinity) || value.RawEquals(cty.NegativeInfinity) {
+                panic("cannot convert infinity to string")
+            }
+            return value.AsBigFloat().Text('f', -1)
+        default:
+            panic("unsupported primitive type")
+            //return ""
+        }
+    }
 }
 
 // PostLoad resolves variable expressions
 func (l Terraform12ResourceLoader) PostLoad(inputResources FileResources) ([]assertion.Resource, error) {
-	return inputResources.Resources, nil
+    return inputResources.Resources, nil
 }

--- a/linter/terraform_v12_test.go
+++ b/linter/terraform_v12_test.go
@@ -92,7 +92,7 @@ func TestTerraform12VariableWithNoDefault(t *testing.T) {
 	resources := loadResources12ToTest(t, "./testdata/resources/uses_variables.tf")
 	assert.Equal(t, len(resources), 1, "Expecting 1 resource")
 	tags := getResourceTags(resources[0])
-	assert.Equal(t, "", tags["department"], "Unexpected value for variable with no default")
+	assert.Equal(t, "UNDEFINED", tags["department"], "Unexpected value for variable with no default")
 }
 
 func TestTerraform12FunctionCall(t *testing.T) {


### PR DESCRIPTION
Closes #146

bug fix. Resource properties created dynamically that are referenced in static analysis are given a static string as value for rule checks. Intended to provide a way to check for "present" properties while not being able to resolve a given value from terraform.