### PR TITLE
Expose Terraform block ID so it could be linted

### DIFF
--- a/linter/terraform.go
+++ b/linter/terraform.go
@@ -247,6 +247,10 @@ func getResources(filename string, ast *ast.File, objects []interface{}, categor
 					for resourceID, templateResource := range templateResource.(map[string]interface{}) {
 						properties := getProperties(templateResource)
 						lineNumber := getResourceLineNumber(resourceType, resourceID, filename, ast)
+						// Expose block ID so it could be linted e.g.
+						// resource "aws_s3_bucket" "web" { ... }
+						// The block id here is "web".
+						properties["__id__"] = resourceID
 						properties["__file__"] = filename
 						properties["__dir__"] = filepath.Dir(filename)
 						tr := assertion.Resource{


### PR DESCRIPTION
Hello,

This PR implemented the suggested enhancement in #160
After taking a deeper look into the code, I found there are 2 internal values exposed already, so I followed the same style. for both tf11 and tf12 tf parsers.

If the PR is primarily accepted I will update the documentation and add an example.

Thanks.