### PR TITLE
Add support for all Terraform blocks

### DIFF
--- a/linter/terraform.go
+++ b/linter/terraform.go
@@ -249,8 +249,8 @@ func getResources(filename string, ast *ast.File, objects []interface{}, categor
 						lineNumber := getResourceLineNumber(resourceType, resourceID, filename, ast)
 						// Expose block ID so it could be linted e.g.
 						// resource "aws_s3_bucket" "web" { ... }
-						// The block id here is "web".
-						properties["__id__"] = resourceID
+						// The block name/id here is "web".
+						properties["__name__"] = resourceID
 						properties["__file__"] = filename
 						properties["__dir__"] = filepath.Dir(filename)
 						tr := assertion.Resource{


### PR DESCRIPTION
Right now there is only support for the following Terraform blocks "resource", "data", "provider", and "module".

This PR to add support for other blocks "locals", "output", "provider", "terraform", "variable".
So they also could be lined.

This fixes issues no.:
- #163
- #158
- #18

Thanks.