### PR TITLE
Apply rules per category if any

### DIFF
--- a/assertion/rules.go
+++ b/assertion/rules.go
@@ -142,6 +142,11 @@ func CheckRule(rule Rule, resource Resource, e ExternalRuleInvoker) (string, []V
 			return "FAILURE", violations, err
 		}
 		if expressionResult.Status != "OK" {
+			// If the rule has category (e.g. Terraform rules), then return violations for that category only.
+			// If the rule has no category it will be applied to all resources as normal.
+			if rule.Category != "" && rule.Category != resource.Category {
+			    break
+			}
 			returnStatus = expressionResult.Status
 			v := Violation{
 				RuleID:           rule.ID,


### PR DESCRIPTION
Hello,

This small change makes it possible to run rules against resources in the same category. Like in Terraform.

This fixes the following issues:
- #135
- #165

Thanks.
