### PR TITLE
change back to release bot token and remove dispatch action

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,8 +1,9 @@
 name: Build & Deploy
 
 on:
-  repository_dispatch:
-    types: [release]
+  push:
+    tags:
+      - 'v*.*.*'
 
 jobs:
   build:

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -24,11 +24,6 @@ jobs:
     - name: Bump version and push tag
       uses: anothrNick/github-tag-action@1.19.0
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.gh_actions_token }}
         WITH_V: true
         DEFAULT_BUMP: minor
-    - name: Trigger release
-      uses: peter-evans/repository-dispatch@v1.0.0
-      with:
-        token: ${{ secrets.gh_actions_token }}
-        event-type: release


### PR DESCRIPTION
Removing the dispatch action since tagging with PAT should kick off the deploy.