### PR TITLE
Fix/exception not loaded on terraform builtin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,4 @@ cover-cli:
 smoke-test:
 	@$(BUILD_DIR)/config-lint -terraform cli/testdata/smoketest_tf12.tf
 	@$(BUILD_DIR)/config-lint -tfparser tf11 -terraform cli/testdata/smoketest_tf11.tf
-
+	@$(BUILD_DIR)/config-lint -tfparser tf11 -terraform -profile cli/testdata/profile-exceptions.yml cli/testdata/smoketest_exceptions.tf

--- a/cli/app.go
+++ b/cli/app.go
@@ -136,7 +136,6 @@ func main() {
 		fmt.Printf("Failed to load rules: %v\n", err)
 		os.Exit(-1)
 	}
-	ruleSets = addExceptions(ruleSets, profileOptions.Exceptions)
 	// Same rule set applies to both TerraformBuiltInRules and Terraform11BuiltInRules
 	// loadBuiltInRuleSet can be called recursively against a directory, as done here,
 	// or can be called against a single file, as done with lint-rule.yml
@@ -152,6 +151,9 @@ func main() {
 		fmt.Println("No rules")
 		os.Exit(-1)
 	}
+
+	ruleSets = addExceptions(ruleSets, profileOptions.Exceptions)
+
 	os.Exit(applyRules(ruleSets, configFilenames, linterOptions, DefaultReportWriter{Writer: os.Stdout}))
 }
 

--- a/cli/testdata/profile-exceptions.yml
+++ b/cli/testdata/profile-exceptions.yml
@@ -1,0 +1,16 @@
+---
+
+terraform: true
+
+files:
+  - "*.tf"
+
+exceptions:
+  - RuleID: IAM_ROLE_WILDCARD_ACTION
+    ResourceCategory: resource
+    ResourceType: aws_iam_role
+    ResourceID: role2
+    Comments: Just because
+
+tags:
+  - iam

--- a/cli/testdata/profile.yml
+++ b/cli/testdata/profile.yml
@@ -9,7 +9,7 @@ exceptions:
   - RuleID: ROLE_WILDCARD_ACTION
     ResourceCategory: resource
     ResourceType: aws_iam_role
-    ResouceID: role2
+    ResourceID: role2
     Comments: Just because
 
 tags:

--- a/cli/testdata/smoketest_exceptions.tf
+++ b/cli/testdata/smoketest_exceptions.tf
@@ -1,0 +1,19 @@
+resource "aws_iam_role" "role2" {
+  name = "role2"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "*",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -32,7 +32,7 @@ exceptions:
   - RuleID: S3_BUCKET_ACL
     ResourceCategory: resource
     ResourceType: aws_s3_bucket
-    ResouceID: simple_website
+    ResourceID: simple_website
     Comments: This bucket hosts a public website
 ```
 


### PR DESCRIPTION
Exceptions in profile do not apply on terraform builtin rules.

It is because the exceptions are parsed before the addition of the builtin rules.

This PR add a smoke-test to reproduce the issue and fix it.