### PR TITLE
Support moved block syntax from Terraform 1.1

### DIFF
--- a/linter/terraform_v12.go
+++ b/linter/terraform_v12.go
@@ -35,13 +35,14 @@ var (
 		"resource",
 		"terraform",
 		"variable",
+		"moved",
 	}
 
 	blockLabelSyntax = map[string][]string{
 		"TypeAndName":  []string{"data", "resource"},
 		"TypeOnly":     []string{"provider"},
 		"NameOnly":     []string{"module", "output", "variable"},
-		"NoTypeNoName": []string{"locals", "terraform"},
+		"NoTypeNoName": []string{"locals", "terraform", "moved"},
 	}
 )
 

--- a/linter/terraform_v12_test.go
+++ b/linter/terraform_v12_test.go
@@ -524,3 +524,10 @@ func TestTerraform12FileFunctionReferenceFileAbsoultePath(t *testing.T) {
 	os.RemoveAll(tempResourceDir)
 	os.RemoveAll(tempReferenceDir)
 }
+
+func TestSyntaxMoved(t *testing.T) {
+  // Allow parsing Terraform 1.1 syntax with `moved` block
+  // with a v0.12 parser
+	loadResources12ToTest(t, "./testdata/resources/moved.tf")
+}
+

--- a/linter/testdata/resources/moved.tf
+++ b/linter/testdata/resources/moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = "from"
+  to = "to"
+}

--- a/linter/tf12parser/parser_test.go
+++ b/linter/tf12parser/parser_test.go
@@ -61,6 +61,11 @@ resource "aws_instance" "first" {
     environment = lookup(var.default_tags,"environment","dev")
   }
 }
+
+moved {
+  from = "x"
+  to = "y"
+}
 `)
 
 	blocks, err := parser.ParseDirectory(filepath.Dir(path))
@@ -122,6 +127,10 @@ resource "aws_instance" "first" {
 	assert.Equal(t, "the-cats-mother", dataBlocks[0].Labels()[1])
 
 	assert.Equal(t, "boots", dataBlocks[0].GetAttribute("name").Value().AsString())
+
+	// moved
+	movedBlocks := blocks.OfType("moved")
+	require.Len(t, movedBlocks, 1)
 }
 
 func Test_Modules(t *testing.T) {

--- a/linter/tf12parser/schema.go
+++ b/linter/tf12parser/schema.go
@@ -20,6 +20,9 @@ var terraformSchema = &hcl.BodySchema{
 			Type: "locals",
 		},
 		{
+			Type: "moved",
+		},
+		{
 			Type:       "output",
 			LabelNames: []string{"name"},
 		},


### PR DESCRIPTION
Add support for loading Terraform files with a `moved` block from Terraform 1.1.

PR does not check for Terraform version and parses a `moved` block with a new 0.12 parser.

Fixes #224